### PR TITLE
Add unfold and zipWithIndex methods

### DIFF
--- a/yaes-data/src/main/scala/in/rcard/yaes/Flow.scala
+++ b/yaes-data/src/main/scala/in/rcard/yaes/Flow.scala
@@ -406,6 +406,34 @@ object Flow {
       count
     }
 
+    /** Returns a flow that pairs each element of the original flow with its index as a Long
+     * and  beginning at 0L
+     *
+     * Example:
+     * {{{
+     * val originalFlow = Flow("a", "b", "c")
+     * val result = scala.collection.mutable.ArrayBuffer[(String, Int)]()
+     *
+     * originalFlow
+     *   .zipWithIndex()
+     *   .collect { value =>
+     *     result += value
+     *   }
+     * // result contains: ("a", 0), ("b", 1), ("c", 2)
+     * }}}
+     *
+     * @return
+     * A flow that pairs each element of the original flow with its index as a Long
+     * * and beginning at 0L
+     */
+    def zipWithIndex(): Flow[(A, Int)] = Flow.flow {
+      var index = 0
+      originalFlow.collect { a =>
+        Flow.emit((a, index))
+        index += 1
+      }
+    }
+
   }
 
   /** Creates a flow using the given builder block that emits values through the FlowCollector. The

--- a/yaes-data/src/main/scala/in/rcard/yaes/Flow.scala
+++ b/yaes-data/src/main/scala/in/rcard/yaes/Flow.scala
@@ -411,7 +411,7 @@ object Flow {
      * Example:
      * {{{
      * val originalFlow = Flow("a", "b", "c")
-     * val result = scala.collection.mutable.ArrayBuffer[(String, Int)]()
+     * val result = scala.collection.mutable.ArrayBuffer[(String, Long)]()
      *
      * originalFlow
      *   .zipWithIndex()

--- a/yaes-data/src/main/scala/in/rcard/yaes/Flow.scala
+++ b/yaes-data/src/main/scala/in/rcard/yaes/Flow.scala
@@ -510,6 +510,26 @@ object Flow {
     collector.emit(value)
   }
 
+  /**
+   * Creates a flow by successively applying a function to a seed value to generate elements and a new state.
+   *
+   * {{{Example:
+   * // Creating a flow via unfold
+   * 
+   * }}}
+   * @param seed the initial state used to generate the first element
+   * @param step a function that takes the current state and returns an `Option` containing a tuple of 
+   *             the next element and the new state, or `None` to terminate the flow
+   * @return a flow containing the sequence of elements generated
+   */
+  def unfold[S, A](seed: S)(step: S => Option[(A, S)]): Flow[A] = flow {
+    var next = step(seed)
+    while (next.isDefined) {
+      Flow.emit(next.get._1)
+      next = step(next.get._2)
+    }
+  }
+  
   /** Creates a flow that emits the given varargs elements.
     *
     * Example:

--- a/yaes-data/src/main/scala/in/rcard/yaes/Flow.scala
+++ b/yaes-data/src/main/scala/in/rcard/yaes/Flow.scala
@@ -406,8 +406,7 @@ object Flow {
       count
     }
 
-    /** Returns a flow that pairs each element of the original flow with its index as a Long
-     * and  beginning at 0L
+    /** Returns a flow that pairs each element of the original flow with its index beginning at 0
      *
      * Example:
      * {{{
@@ -423,8 +422,7 @@ object Flow {
      * }}}
      *
      * @return
-     * A flow that pairs each element of the original flow with its index as a Long
-     * * and beginning at 0L
+     * A flow that pairs each element of the original flow with its index beginning at 0
      */
     def zipWithIndex(): Flow[(A, Int)] = Flow.flow {
       var index = 0
@@ -513,10 +511,22 @@ object Flow {
   /**
    * Creates a flow by successively applying a function to a seed value to generate elements and a new state.
    *
-   * {{{Example:
+   * Example:
+   * {{{
    * // Creating a flow via unfold
-   * 
+   * val fibonacciFlow = Flow.unfold((0, 1)) { case (a, b) =>
+   *   if (a > 50) None
+   *   else Some((a, (b, a + b)))
+   * }
+   *
+   * val result = scala.collection.mutable.ArrayBuffer[Int]()
+   * fibonacciFlow.collect { value =>
+   *   actualResult += value
+   * }
+   *
+   * // result contains: 0, 1, 1, 2, 3, 5, 8, 13, 21, 34
    * }}}
+ *
    * @param seed the initial state used to generate the first element
    * @param step a function that takes the current state and returns an `Option` containing a tuple of 
    *             the next element and the new state, or `None` to terminate the flow

--- a/yaes-data/src/main/scala/in/rcard/yaes/Flow.scala
+++ b/yaes-data/src/main/scala/in/rcard/yaes/Flow.scala
@@ -424,8 +424,8 @@ object Flow {
      * @return
      * A flow that pairs each element of the original flow with its index beginning at 0
      */
-    def zipWithIndex(): Flow[(A, Int)] = Flow.flow {
-      var index = 0
+    def zipWithIndex(): Flow[(A, Long)] = Flow.flow {
+      var index: Long = 0L
       originalFlow.collect { a =>
         Flow.emit((a, index))
         index += 1

--- a/yaes-data/src/test/scala/in/rcard/yaes/FlowSpec.scala
+++ b/yaes-data/src/test/scala/in/rcard/yaes/FlowSpec.scala
@@ -238,7 +238,7 @@ class FlowSpec extends AnyFlatSpec with Matchers {
 
     result should be(3)
   }
-  
+
   it should "return 0 if no values are emitted" in {
     val flow: Flow[Int] = Flow.flow[Int] {}
 
@@ -246,4 +246,16 @@ class FlowSpec extends AnyFlatSpec with Matchers {
 
     result should be(0)
   }
+
+  "zipWithIndex" should "create a flow that adds its index to the value" in {
+    val flow: Flow[String] = Flow("a", "b", "c")
+
+    val actualResult = scala.collection.mutable.ArrayBuffer[(String, Int)]()
+    flow.zipWithIndex().collect {
+      actualResult += _
+    }
+
+    actualResult should contain theSameElementsInOrderAs Seq("a" -> 0, "b" -> 1, "c" -> 2)
+  }
+
 }

--- a/yaes-data/src/test/scala/in/rcard/yaes/FlowSpec.scala
+++ b/yaes-data/src/test/scala/in/rcard/yaes/FlowSpec.scala
@@ -250,7 +250,7 @@ class FlowSpec extends AnyFlatSpec with Matchers {
   "zipWithIndex" should "create a flow that adds its index to the value" in {
     val flow: Flow[String] = Flow("a", "b", "c")
 
-    val actualResult = scala.collection.mutable.ArrayBuffer[(String, Int)]()
+    val actualResult = scala.collection.mutable.ArrayBuffer[(String, Long)]()
     flow.zipWithIndex().collect {
       actualResult += _
     }

--- a/yaes-data/src/test/scala/in/rcard/yaes/FlowSpec.scala
+++ b/yaes-data/src/test/scala/in/rcard/yaes/FlowSpec.scala
@@ -258,4 +258,17 @@ class FlowSpec extends AnyFlatSpec with Matchers {
     actualResult should contain theSameElementsInOrderAs Seq("a" -> 0, "b" -> 1, "c" -> 2)
   }
 
+  "unfold" should "create a flow from a seed and a step function" in {
+    val fibonacciFlow = Flow.unfold((0, 1)) { case (a, b) =>
+      if (a > 50) None
+      else Some((a, (b, a + b)))
+    }
+
+    val actualResult = scala.collection.mutable.ArrayBuffer[Int]()
+    fibonacciFlow.collect { value =>
+      actualResult += value
+    }
+
+    actualResult should contain theSameElementsInOrderAs Seq(0, 1, 1, 2, 3, 5, 8, 13, 21, 34)
+  }
 }


### PR DESCRIPTION
These changes introduce the following:

**Unfold method**: A utility function to generate collections from an initial seed value and a function that generates successive elements.
**ZipWithIndex method**: A method to pair each element of a collection with its index.