### PR TITLE
Adds zipWith operation on flows

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,11 +46,13 @@ lazy val yaes = (project in file("."))
 
 lazy val dependencies =
   new {
-    val scalatestVersion = "3.2.19"
-    val scalatest        = "org.scalatest" %% "scalatest" % scalatestVersion
+    val scalatestVersion  = "3.2.19"
+    val scalatest         = "org.scalatest"     %% "scalatest"       % scalatestVersion
+    val scalacheckVersion = "3.2.19.0"
+    val scalacheck        = "org.scalatestplus" %% "scalacheck-1-18" % scalacheckVersion
   }
 
-
 lazy val commonDependencies = Seq(
-  dependencies.scalatest % Test
+  dependencies.scalatest  % Test,
+  dependencies.scalacheck % Test
 )

--- a/yaes-core/src/main/scala/in/rcard/yaes/Async.scala
+++ b/yaes-core/src/main/scala/in/rcard/yaes/Async.scala
@@ -292,6 +292,8 @@ object Async {
       *   The other flow to combine with this flow.
       * @param f
       *   A function that takes a pair of elements from both flows and produces a new element.
+      * @param async
+      *   The async context
       * @return
       *   A new flow emitting elements resulting from applying the function `f` to pairs of elements
       *   from both flows.

--- a/yaes-core/src/main/scala/in/rcard/yaes/Async.scala
+++ b/yaes-core/src/main/scala/in/rcard/yaes/Async.scala
@@ -296,7 +296,7 @@ object Async {
       *   A new flow emitting elements resulting from applying the function `f` to pairs of elements
       *   from both flows.
       */
-    def zipWith[B, C](other: Flow[B])(f: (A, B) => C)(using asyc: Async): Flow[C] =
+    def zipWith[B, C](other: Flow[B])(f: (A, B) => C)(using async: Async): Flow[C] =
       Flow.flow {
         val canEmitPair = new Semaphore(0)
         val canGetA     = new Semaphore(1)

--- a/yaes-core/src/main/scala/in/rcard/yaes/Async.scala
+++ b/yaes-core/src/main/scala/in/rcard/yaes/Async.scala
@@ -3,7 +3,13 @@ package in.rcard.yaes
 import in.rcard.yaes.Async.Async
 import in.rcard.yaes.Raise.Raise
 
-import java.util.concurrent.{CancellationException, CompletableFuture, ConcurrentLinkedQueue, ExecutionException, Future, Semaphore, StructuredTaskScope}
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
+import java.util.concurrent.Semaphore
+import java.util.concurrent.StructuredTaskScope
 import java.util.concurrent.StructuredTaskScope.ShutdownOnFailure
 import java.util.concurrent.StructuredTaskScope.Subtask
 import java.util.function.Consumer
@@ -229,35 +235,33 @@ object Async {
   type TimedOut = TimedOut.type
 
   extension [A](flow: Flow[A]) {
-
-    /** Launches the collection of this flow in the current Async context. Returns a Fiber that
+    /** Launches the collection of this flow in the current Async context. Returns a Fiber that 
       * represents the launched coroutine and can be used to join or cancel collection of the flow.
-      *
+      * 
       * This is a terminal operator on the flow. The flow collection is launched when this function
       * is called and is performed asynchronously. This operator is usually used with extension
       * functions like `onEach`, `onCompletion`, and other operators to process all emitted values
       * and handle exceptions within the flow.
-      *
+      * 
       * Example:
       * {{{
       * val flow = Flow(1, 2, 3)
-      *
+      * 
       * // Launch the flow in the current Async context
       * val fiber = flow
       *   .onEach { value => println(s"Processed value: $value") }
       *   .forkOn()
-      *
+      *   
       * // Do some other work
-      *
+      * 
       * // Wait for the flow collection to complete
       * fiber.join()
       * }}}
-      *
+      * 
       * @param async
       *   the async context to launch the flow in
       * @return
-      *   a Fiber that represents the launched computation and can be used for joining or
-      *   cancellation
+      *   a Fiber that represents the launched computation and can be used for joining or cancellation
       */
     def forkOn()(using async: Async): Fiber[Unit] = Async.fork {
       flow.collect { _ => () }

--- a/yaes-core/src/main/scala/in/rcard/yaes/Async.scala
+++ b/yaes-core/src/main/scala/in/rcard/yaes/Async.scala
@@ -3,19 +3,13 @@ package in.rcard.yaes
 import in.rcard.yaes.Async.Async
 import in.rcard.yaes.Raise.Raise
 
-import java.util.concurrent.CancellationException
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.Future
-import java.util.concurrent.StructuredTaskScope
+import java.util.concurrent.{CancellationException, CompletableFuture, ConcurrentLinkedQueue, ExecutionException, Future, Semaphore, StructuredTaskScope}
 import java.util.concurrent.StructuredTaskScope.ShutdownOnFailure
 import java.util.concurrent.StructuredTaskScope.Subtask
 import java.util.function.Consumer
 import scala.collection.immutable.Stream.Cons
 import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
-
 import Async.Cancelled
 
 /** Represents an asynchronous computation that can be controlled.
@@ -235,37 +229,113 @@ object Async {
   type TimedOut = TimedOut.type
 
   extension [A](flow: Flow[A]) {
-    /** Launches the collection of this flow in the current Async context. Returns a Fiber that 
+
+    /** Launches the collection of this flow in the current Async context. Returns a Fiber that
       * represents the launched coroutine and can be used to join or cancel collection of the flow.
-      * 
+      *
       * This is a terminal operator on the flow. The flow collection is launched when this function
       * is called and is performed asynchronously. This operator is usually used with extension
       * functions like `onEach`, `onCompletion`, and other operators to process all emitted values
       * and handle exceptions within the flow.
-      * 
+      *
       * Example:
       * {{{
       * val flow = Flow(1, 2, 3)
-      * 
+      *
       * // Launch the flow in the current Async context
       * val fiber = flow
       *   .onEach { value => println(s"Processed value: $value") }
       *   .forkOn()
-      *   
+      *
       * // Do some other work
-      * 
+      *
       * // Wait for the flow collection to complete
       * fiber.join()
       * }}}
-      * 
+      *
       * @param async
       *   the async context to launch the flow in
       * @return
-      *   a Fiber that represents the launched computation and can be used for joining or cancellation
+      *   a Fiber that represents the launched computation and can be used for joining or
+      *   cancellation
       */
     def forkOn()(using async: Async): Fiber[Unit] = Async.fork {
       flow.collect { _ => () }
     }
+
+    /**
+     * Combines the elements of this flow with another flow using the provided function.
+     *
+     * The method emits elements by applying the provided function `f` to pairs of elements
+     * from the current flow and the `other` flow. It only emits elements when both flows
+     * provide values.
+     *
+     * Example:
+     * {{{
+     * val flow1 = Flow("a", "b", "c", "d")
+     * val flow2 = Flow(1, 2, 3)
+     * val combined = flow1.zipWith(flow2)((_, _))
+     *
+     * val result = scala.collection.mutable.ArrayBuffer[(String, Int)]()
+     *
+     * combined.collect { result += _ }
+     *
+     * // Result contains the elements ("a", 1), ("b", 2), ("c", 3)
+     * }}}
+     *
+     * @param other
+     * The other flow to combine with this flow.
+     * @param f
+     * A function that takes a pair of elements from both flows and produces a new element.
+     * @return
+     * A new flow emitting elements resulting from applying the function `f` to pairs
+     * of elements from both flows.
+     */
+    def zipWith[B, C](other: Flow[B])(f: (A, B) => C): Flow[C] =
+      Flow.flow {
+        Async.run {
+          val canEmitPair = new Semaphore(0)
+          val canGetA     = new Semaphore(1)
+          val canGetB     = new Semaphore(1)
+          var a           = null.asInstanceOf[A]
+          var b           = null.asInstanceOf[B]
+          val zipFiber = Async.fork {
+            try {
+              while (true) {
+                canEmitPair.acquire(2)
+                Flow.emit(f(a, b))
+                canGetA.release()
+                canGetB.release()
+              }
+            } catch {
+              case _: InterruptedException => ()
+            }
+          }
+          val fiberFlowA = flow
+            .onEach { value =>
+              canGetA.acquire()
+              a = value
+              canEmitPair.release()
+            }
+            .forkOn()
+          val fiberFlowB = other
+            .onEach { value =>
+              canGetB.acquire()
+              b = value
+              canEmitPair.release()
+            }
+            .forkOn()
+          fiberFlowA.onComplete { _ =>
+            fiberFlowB.cancel()
+            zipFiber.cancel()
+          }
+          fiberFlowB.onComplete { _ =>
+            fiberFlowA.cancel()
+            zipFiber.cancel()
+          }
+          zipFiber.join()
+        }
+      }
   }
 
   /** Lifts a computation to the Async context.

--- a/yaes-core/src/test/scala/in/rcard/yaes/AsyncSpec.scala
+++ b/yaes-core/src/test/scala/in/rcard/yaes/AsyncSpec.scala
@@ -548,4 +548,16 @@ class AsyncSpec extends AnyFlatSpec with Matchers {
 
     actualQueue.toArray should contain theSameElementsInOrderAs List("before", "flow", "after")
   }
+
+  "zipWith" should "mix the corresponding elements of the two flows with the function" in {
+    val flow1 = Flow("a", "b", "c", "d")
+    val flow2 = Flow(1, 2, 3)
+    val combined = flow1.zipWith(flow2)((_, _))
+
+    val actualResult = scala.collection.mutable.ArrayBuffer[(String, Int)]()
+
+    combined.collect { actualResult += _ }
+
+    actualResult should contain theSameElementsInOrderAs Seq("a" -> 1, "b" -> 2, "c" -> 3)
+  }
 }

--- a/yaes-core/src/test/scala/in/rcard/yaes/AsyncSpec.scala
+++ b/yaes-core/src/test/scala/in/rcard/yaes/AsyncSpec.scala
@@ -560,4 +560,30 @@ class AsyncSpec extends AnyFlatSpec with Matchers {
 
     actualResult should contain theSameElementsInOrderAs Seq("a" -> 1, "b" -> 2, "c" -> 3)
   }
+
+  it should "mix the values of one flow with itself" in {
+    val flow = Flow(1, 2, 3)
+    val combined = flow.zipWith(flow)((_, _))
+
+    val actualResult = scala.collection.mutable.ArrayBuffer[(Int, Int)]()
+
+    combined.collect {
+      actualResult += _
+    }
+
+    actualResult should contain theSameElementsInOrderAs Seq(1 -> 1, 2 -> 2, 3 -> 3)
+  }
+
+  it should "return the empty flow when one of the two flows is empty" in {
+    val empty = Flow()
+    val nonEmpty = Flow(1, 2, 3)
+
+    val emptyLeft = empty.zipWith(nonEmpty)((_, _))
+    val emptyRight = nonEmpty.zipWith(empty)((_, _))
+    val emptyBoth = empty.zipWith(empty)((_, _))
+
+    emptyLeft.count() shouldBe 0
+    emptyRight.count() shouldBe 0
+    emptyBoth.count() shouldBe 0
+  }
 }

--- a/yaes-core/src/test/scala/in/rcard/yaes/AsyncSpec.scala
+++ b/yaes-core/src/test/scala/in/rcard/yaes/AsyncSpec.scala
@@ -548,49 +548,4 @@ class AsyncSpec extends AnyFlatSpec with Matchers {
 
     actualQueue.toArray should contain theSameElementsInOrderAs List("before", "flow", "after")
   }
-
-  "zipWith" should "mix the corresponding elements of the two flows with the function" in {
-    val actualQueue = new ConcurrentLinkedQueue[(String, Int)]()
-    val flow1       = Flow("a", "b", "c", "d")
-    val flow2       = Flow(1, 2, 3)
-    Async.run {
-      val combined = flow1.zipWith(flow2)((_, _))
-      combined.collect {
-        actualQueue.add(_)
-      }
-    }
-    actualQueue.toArray() should contain theSameElementsInOrderAs List("a" -> 1, "b" -> 2, "c" -> 3)
-  }
-
-  it should "mix the values of one flow with itself" in {
-    val actualQueue = new ConcurrentLinkedQueue[(Int, Int)]()
-    val flow        = Flow(1, 2, 3)
-    Async.run {
-      val combined = flow.zipWith(flow)((_, _))
-      combined.collect {
-        actualQueue.add(_)
-      }
-    }
-    actualQueue.toArray() should contain theSameElementsInOrderAs List(1 -> 1, 2 -> 2, 3 -> 3)
-  }
-
-  it should "return the empty flow when one of the two flows is empty" in {
-    val empty    = Flow()
-    val nonEmpty = Flow(1, 2, 3)
-    val emptyLeftCount = Async.run {
-      val emptyLeft = empty.zipWith(nonEmpty)((_, _))
-      emptyLeft.count()
-    }
-    val emptyRightCount = Async.run {
-      val emptyRight = nonEmpty.zipWith(empty)((_, _))
-      emptyRight.count()
-    }
-    val emptyBothCount = Async.run {
-      val emptyBoth = empty.zipWith(empty)((_, _))
-      emptyBoth.count()
-    }
-    emptyLeftCount shouldBe 0
-    emptyRightCount shouldBe 0
-    emptyBothCount shouldBe 0
-  }
 }

--- a/yaes-core/src/test/scala/in/rcard/yaes/FlowZipWithSpec.scala
+++ b/yaes-core/src/test/scala/in/rcard/yaes/FlowZipWithSpec.scala
@@ -1,0 +1,152 @@
+package in.rcard.yaes
+
+import in.rcard.yaes.Async.*
+import org.scalacheck.{Gen, Shrink}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.concurrent.duration.Duration
+import scala.language.postfixOps
+
+class FlowZipWithSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
+
+  val genMillis: Gen[Duration] =
+    Gen
+      .oneOf[Long](0, 50, 100, 150, 200)
+      .map(_ * 1000 * 1000) // to millis
+      .map(Duration.fromNanos)
+
+  // I disable the shrinking for the generator of Durations
+  implicit val noShrink: Shrink[Duration] = Shrink.shrinkAny[Duration]
+
+  private def delayedEmpty(t1: Duration)(using async: Async): Flow[Int] = Flow.flow {
+    Async.delay(t1)
+  }
+
+  private def delayedOne[A](t1: Duration, t2: Duration)(a: A)(using async: Async): Flow[A] =
+    Flow.flow {
+      Async.delay(t1)
+      Flow.emit(a)
+      Async.delay(t2)
+    }
+
+  private def delayedTwo[A](t1: Duration, t2: Duration, t3: Duration)(a1: A, a2: A)(using
+      async: Async
+  ): Flow[A] = Flow.flow {
+    Async.delay(t1)
+    Flow.emit(a1)
+    Async.delay(t2)
+    Flow.emit(a2)
+    Async.delay(t3)
+  }
+
+  "zipWith" should "zip two empty flows" in {
+    forAll(genMillis, genMillis) { (delay1, delay2) =>
+      val actualQueue = new ConcurrentLinkedQueue[(Int, Int)]()
+      Async.run {
+        val flow1  = delayedEmpty(delay1)
+        val flow2  = delayedEmpty(delay2)
+        val zipped = flow1.zipWith(flow2)((_, _))
+        zipped.collect {
+          actualQueue.add(_)
+        }
+      }
+      actualQueue shouldBe empty
+    }
+  }
+
+  it should "zip one empty flow with one non empty" in {
+    forAll(genMillis, genMillis, genMillis) { (delay1, delay2, delay3) =>
+      val actualQueue = new ConcurrentLinkedQueue[(Int, Int)]()
+      Async.run {
+        val flow1  = delayedEmpty(delay1)
+        val flow2  = delayedOne(delay2, delay3)(1)
+        val zipped = flow1.zipWith(flow2)((_, _))
+        zipped.collect {
+          actualQueue.add(_)
+        }
+      }
+      actualQueue shouldBe empty
+    }
+  }
+
+  it should "zip one non empty with one empty" in {
+    forAll(genMillis, genMillis, genMillis) { (delay1, delay2, delay3) =>
+      val actualQueue = new ConcurrentLinkedQueue[(Int, Int)]()
+      Async.run {
+        val flow1  = delayedOne(delay1, delay2)(1)
+        val flow2  = delayedEmpty(delay3)
+        val zipped = flow1.zipWith(flow2)((_, _))
+        zipped.collect {
+          actualQueue.add(_)
+        }
+      }
+      actualQueue shouldBe empty
+    }
+  }
+
+  it should "zip to flows of one element" in {
+    forAll(genMillis, genMillis, genMillis, genMillis) { (delay1, delay2, delay3, delay4) =>
+      val actualQueue = new ConcurrentLinkedQueue[(Char, Int)]()
+      Async.run {
+        val flow1  = delayedOne(delay1, delay2)('A')
+        val flow2  = delayedOne(delay3, delay4)(1)
+        val zipped = flow1.zipWith(flow2)((_, _))
+        zipped.collect {
+          actualQueue.add(_)
+        }
+      }
+      actualQueue.toArray should contain theSameElementsInOrderAs Seq('A' -> 1)
+    }
+  }
+
+  it should "zip a flow with one element with another with two" in {
+    forAll(genMillis, genMillis, genMillis, genMillis, genMillis) {
+      (delay1, delay2, delay3, delay4, delay5) =>
+        val actualQueue = new ConcurrentLinkedQueue[(Char, Int)]()
+        Async.run {
+          lazy val flow1 = delayedOne(delay1, delay2)('A')
+          lazy val flow2 = delayedTwo(delay3, delay4, delay5)(1, 2)
+          val zipped     = flow1.zipWith(flow2)((_, _))
+          zipped.collect {
+            actualQueue.add(_)
+          }
+        }
+        actualQueue.toArray should contain theSameElementsInOrderAs Seq('A' -> 1)
+    }
+  }
+
+  it should "zip a flow with two elements with another with one" in {
+    forAll(genMillis, genMillis, genMillis, genMillis, genMillis) {
+      (delay1, delay2, delay3, delay4, delay5) =>
+        val actualQueue = new ConcurrentLinkedQueue[(Char, Int)]()
+        Async.run {
+          lazy val flow1 = delayedTwo(delay1, delay2, delay3)('A', 'B')
+          lazy val flow2 = delayedOne(delay3, delay4)(1)
+          val zipped     = flow1.zipWith(flow2)((_, _))
+          zipped.collect {
+            actualQueue.add(_)
+          }
+        }
+        actualQueue.toArray should contain theSameElementsInOrderAs Seq('A' -> 1)
+    }
+  }
+
+  it should "zip two flows with two elements each" in {
+    forAll(genMillis, genMillis, genMillis, genMillis, genMillis, genMillis) {
+      (delay1, delay2, delay3, delay4, delay5, delay6) =>
+        val actualQueue = new ConcurrentLinkedQueue[(Char, Int)]()
+        Async.run {
+          lazy val flow1 = delayedTwo(delay1, delay2, delay3)('A', 'B')
+          lazy val flow2 = delayedTwo(delay3, delay4, delay5)(1, 2)
+          val zipped     = flow1.zipWith(flow2)((_, _))
+          zipped.collect {
+            actualQueue.add(_)
+          }
+        }
+        actualQueue.toArray should contain theSameElementsInOrderAs Seq('A' -> 1, 'B' -> 2)
+    }
+  }
+}

--- a/yaes-core/src/test/scala/in/rcard/yaes/FlowZipWithSpec.scala
+++ b/yaes-core/src/test/scala/in/rcard/yaes/FlowZipWithSpec.scala
@@ -18,135 +18,104 @@ class FlowZipWithSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
       .map(_ * 1000 * 1000) // to millis
       .map(Duration.fromNanos)
 
-  // I disable the shrinking for the generator of Durations
-  implicit val noShrink: Shrink[Duration] = Shrink.shrinkAny[Duration]
-
-  private def delayedEmpty(t1: Duration)(using async: Async): Flow[Int] = Flow.flow {
-    Async.delay(t1)
-  }
-
-  private def delayedOne[A](t1: Duration, t2: Duration)(a: A)(using async: Async): Flow[A] =
-    Flow.flow {
-      Async.delay(t1)
-      Flow.emit(a)
-      Async.delay(t2)
+  private def genFlow[A](as: A*)(using async: Async): Gen[Flow[A]] =
+    for {
+      delays <- Gen.listOfN(as.length + 1, genMillis)
+    } yield Flow.flow[A] {
+      delays.zip(as :+ null).foreach { case (delay, element) =>
+        Async.delay(delay)
+        if (element != null) Flow.emit(element.nn)
+      }
     }
 
-  private def delayedTwo[A](t1: Duration, t2: Duration, t3: Duration)(a1: A, a2: A)(using
-      async: Async
-  ): Flow[A] = Flow.flow {
-    Async.delay(t1)
-    Flow.emit(a1)
-    Async.delay(t2)
-    Flow.emit(a2)
-    Async.delay(t3)
-  }
-
   "zipWith" should "zip two empty flows" in {
-    forAll(genMillis, genMillis) { (delay1, delay2) =>
-      val actualQueue = new ConcurrentLinkedQueue[(Int, Int)]()
-      Async.run {
-        val flow1  = delayedEmpty(delay1)
-        val flow2  = delayedEmpty(delay2)
-        val zipped = flow1.zipWith(flow2)((_, _))
+    Async.run {
+      forAll(genFlow(), genFlow()) { (flow1, flow2) =>
+        val actualQueue = new ConcurrentLinkedQueue[(Any, Any)]()
+        val zipped      = flow1.zipWith(flow2)((_, _))
         zipped.collect {
           actualQueue.add(_)
         }
+        actualQueue shouldBe empty
       }
-      actualQueue shouldBe empty
     }
   }
 
   it should "zip one empty flow with one non empty" in {
-    forAll(genMillis, genMillis, genMillis) { (delay1, delay2, delay3) =>
-      val actualQueue = new ConcurrentLinkedQueue[(Int, Int)]()
-      Async.run {
-        val flow1  = delayedEmpty(delay1)
-        val flow2  = delayedOne(delay2, delay3)(1)
-        val zipped = flow1.zipWith(flow2)((_, _))
+    Async.run {
+      forAll(genFlow(), genFlow('A')) { (flow1, flow2) =>
+        val actualQueue = new ConcurrentLinkedQueue[(Any, Char)]()
+        val zipped      = flow1.zipWith(flow2)((_, _))
         zipped.collect {
           actualQueue.add(_)
         }
+        actualQueue shouldBe empty
       }
-      actualQueue shouldBe empty
     }
   }
 
   it should "zip one non empty with one empty" in {
-    forAll(genMillis, genMillis, genMillis) { (delay1, delay2, delay3) =>
-      val actualQueue = new ConcurrentLinkedQueue[(Int, Int)]()
-      Async.run {
-        val flow1  = delayedOne(delay1, delay2)(1)
-        val flow2  = delayedEmpty(delay3)
-        val zipped = flow1.zipWith(flow2)((_, _))
+    Async.run {
+      forAll(genFlow('A'), genFlow()) { (flow1, flow2) =>
+        val actualQueue = new ConcurrentLinkedQueue[(Char, Any)]()
+        val zipped      = flow1.zipWith(flow2)((_, _))
         zipped.collect {
           actualQueue.add(_)
         }
+        actualQueue shouldBe empty
       }
-      actualQueue shouldBe empty
     }
   }
 
   it should "zip to flows of one element" in {
-    forAll(genMillis, genMillis, genMillis, genMillis) { (delay1, delay2, delay3, delay4) =>
-      val actualQueue = new ConcurrentLinkedQueue[(Char, Int)]()
-      Async.run {
-        val flow1  = delayedOne(delay1, delay2)('A')
-        val flow2  = delayedOne(delay3, delay4)(1)
-        val zipped = flow1.zipWith(flow2)((_, _))
+    Async.run {
+      forAll(genFlow('A'), genFlow(1)) { (flow1, flow2) =>
+        val actualQueue = new ConcurrentLinkedQueue[(Char, Int)]()
+        val zipped      = flow1.zipWith(flow2)((_, _))
         zipped.collect {
           actualQueue.add(_)
         }
+        actualQueue.toArray should contain theSameElementsInOrderAs Seq('A' -> 1)
       }
-      actualQueue.toArray should contain theSameElementsInOrderAs Seq('A' -> 1)
     }
   }
 
   it should "zip a flow with one element with another with two" in {
-    forAll(genMillis, genMillis, genMillis, genMillis, genMillis) {
-      (delay1, delay2, delay3, delay4, delay5) =>
+    Async.run {
+      forAll(genFlow('A'), genFlow(1, 2)) { (flow1, flow2) =>
         val actualQueue = new ConcurrentLinkedQueue[(Char, Int)]()
-        Async.run {
-          lazy val flow1 = delayedOne(delay1, delay2)('A')
-          lazy val flow2 = delayedTwo(delay3, delay4, delay5)(1, 2)
-          val zipped     = flow1.zipWith(flow2)((_, _))
-          zipped.collect {
-            actualQueue.add(_)
-          }
+        val zipped      = flow1.zipWith(flow2)((_, _))
+        zipped.collect {
+          actualQueue.add(_)
         }
         actualQueue.toArray should contain theSameElementsInOrderAs Seq('A' -> 1)
+      }
     }
   }
 
   it should "zip a flow with two elements with another with one" in {
-    forAll(genMillis, genMillis, genMillis, genMillis, genMillis) {
-      (delay1, delay2, delay3, delay4, delay5) =>
+    Async.run {
+      forAll(genFlow('A', 'B'), genFlow(1)) { (flow1, flow2) =>
         val actualQueue = new ConcurrentLinkedQueue[(Char, Int)]()
-        Async.run {
-          lazy val flow1 = delayedTwo(delay1, delay2, delay3)('A', 'B')
-          lazy val flow2 = delayedOne(delay3, delay4)(1)
-          val zipped     = flow1.zipWith(flow2)((_, _))
-          zipped.collect {
-            actualQueue.add(_)
-          }
+        val zipped      = flow1.zipWith(flow2)((_, _))
+        zipped.collect {
+          actualQueue.add(_)
         }
         actualQueue.toArray should contain theSameElementsInOrderAs Seq('A' -> 1)
+      }
     }
   }
 
   it should "zip two flows with two elements each" in {
-    forAll(genMillis, genMillis, genMillis, genMillis, genMillis, genMillis) {
-      (delay1, delay2, delay3, delay4, delay5, delay6) =>
+    Async.run {
+      forAll(genFlow('A', 'B'), genFlow(1, 2)) { (flow1, flow2) =>
         val actualQueue = new ConcurrentLinkedQueue[(Char, Int)]()
-        Async.run {
-          lazy val flow1 = delayedTwo(delay1, delay2, delay3)('A', 'B')
-          lazy val flow2 = delayedTwo(delay3, delay4, delay5)(1, 2)
-          val zipped     = flow1.zipWith(flow2)((_, _))
-          zipped.collect {
-            actualQueue.add(_)
-          }
+        val zipped      = flow1.zipWith(flow2)((_, _))
+        zipped.collect {
+          actualQueue.add(_)
         }
         actualQueue.toArray should contain theSameElementsInOrderAs Seq('A' -> 1, 'B' -> 2)
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request introduces a new `zipWith` method for combining elements of two flows in the `Async` module and includes corresponding updates to the test suite. The most important changes include the addition of the `zipWith` method, its implementation using semaphores for synchronization, and a new test case to validate its functionality.

### New feature: `zipWith` method

* **`zipWith` method added to `Flow` class**: Introduced a new method `zipWith` in `Flow` to combine elements from two flows using a provided function. This method ensures synchronization using semaphores and emits elements only when both flows have values.

### Supporting changes

* **Semaphore import**: Added `java.util.concurrent.Semaphore` to support the synchronization logic in the `zipWith` implementation.

### Testing updates

* **New test case for `zipWith`**: Added a test case in `AsyncSpec` to verify that the `zipWith` method correctly combines corresponding elements from two flows using a specified function.