### PR TITLE
Fix thread scope removal logic in Async to handle completed forked th…

### DIFF
--- a/yaes-core/src/main/scala/in/rcard/yaes/Async.scala
+++ b/yaes-core/src/main/scala/in/rcard/yaes/Async.scala
@@ -175,7 +175,9 @@ class JvmStructuredScope(
           promise.complete(innerTask.get())
         }
       } finally {
-        scopes.remove(Thread.currentThread().threadId)
+        if (forkedThread.isDone) {
+          scopes.remove(forkedThread.get().threadId).orElse(throw new IllegalStateException("shouldn't happen"))
+        }
         innerScope.close()
       }
     })


### PR DESCRIPTION
This pull request fixes the scope management logic in the `Async.scala` file to ensure the proper thread is cleaned up.

Key change:

* [`yaes-core/src/main/scala/in/rcard/yaes/Async.scala`](diffhunk://#diff-9934a4796425a8dc98a2c3776df978f55023385b6efe642f367ee907d9d98091L178-R180): Updated the scope removal logic to check if the forked thread is done before attempting to remove its scope. Added an `IllegalStateException` fallback for cases where the scope removal unexpectedly fails.…reads