### PR TITLE
feat: TASK-1A - add yaes-http-core and yaes-http-client modules to build

### DIFF
--- a/docs/http/client.md
+++ b/docs/http/client.md
@@ -38,24 +38,26 @@ import in.rcard.yaes.*
 import in.rcard.yaes.http.client.*
 import scala.concurrent.duration.*
 
-Raise.run[ConnectionError] {
-  Resource.run {
-    val client = YaesClient.make()
+Sync.runBlocking(30.seconds) {
+  Raise.run[ConnectionError] {
+    Resource.run {
+      val client = YaesClient.make()
 
-    Raise.run[Uri.InvalidUri] {
-      val uri = Uri("https://httpbin.org/get")
-      val response = client.send(HttpRequest.get(uri))
-      println(s"Status: ${response.status}")
-      println(s"Body: ${response.body}")
+      Raise.run[Uri.InvalidUri] {
+        val uri = Uri("https://httpbin.org/get")
+        val response = client.send(HttpRequest.get(uri))
+        println(s"Status: ${response.status}")
+        println(s"Body: ${response.body}")
+      }
     }
   }
 }
 ```
 
 **Required Effects:**
+- **`Sync`** - Required by `YaesClient.send`; use `Sync.runBlocking` (or a `YaesApp` stack) as the outermost handler
 - **`Resource`** - Manages the lifecycle of the underlying Java `HttpClient` (auto-closed on block exit)
 - **`Raise[ConnectionError]`** - Handles transport-level errors (connection refused, timeouts)
-- **`Sync`** - Provided implicitly within `Resource.run`
 
 ---
 

--- a/yaes-http/client/README.md
+++ b/yaes-http/client/README.md
@@ -38,15 +38,17 @@ import in.rcard.yaes.*
 import in.rcard.yaes.http.client.*
 import scala.concurrent.duration.*
 
-Raise.run[ConnectionError] {
-  Resource.run {
-    val client = YaesClient.make()
+Sync.runBlocking(30.seconds) {
+  Raise.run[ConnectionError] {
+    Resource.run {
+      val client = YaesClient.make()
 
-    Raise.run[Uri.InvalidUri] {
-      val uri = Uri("https://httpbin.org/get")
-      val response = client.send(HttpRequest.get(uri))
-      println(s"Status: ${response.status}")
-      println(s"Body: ${response.body}")
+      Raise.run[Uri.InvalidUri] {
+        val uri = Uri("https://httpbin.org/get")
+        val response = client.send(HttpRequest.get(uri))
+        println(s"Status: ${response.status}")
+        println(s"Body: ${response.body}")
+      }
     }
   }
 }
@@ -145,26 +147,28 @@ Raise.run[Uri.InvalidUri] {
 
 - `header(name, value)` — adds or replaces a header (keys are lowercased)
 - `queryParam(name, value)` — appends a query parameter (duplicate keys allowed)
-- `timeout(duration)` — sets the per-request timeout (infinite durations are ignored)
+- `timeout(duration)` — sets the per-request timeout (non-finite or non-positive durations clear any existing timeout)
 
 ## Sending Requests
 
 Use `client.send(request)` to execute a request. The method requires `Sync` and `Raise[ConnectionError]` effects:
 
 ```scala
-Raise.run[ConnectionError] {
-  Resource.run {
-    val client = YaesClient.make()
+Sync.runBlocking(30.seconds) {
+  Raise.run[ConnectionError] {
+    Resource.run {
+      val client = YaesClient.make()
 
-    Raise.run[Uri.InvalidUri] {
-      val uri = Uri("https://httpbin.org/post")
-      val request = HttpRequest.post(uri, "hello")
-        .header("Accept", "application/json")
+      Raise.run[Uri.InvalidUri] {
+        val uri = Uri("https://httpbin.org/post")
+        val request = HttpRequest.post(uri, "hello")
+          .header("Accept", "application/json")
 
-      val response: HttpResponse = client.send(request)
-      println(s"Status: ${response.status}")
-      println(s"Content-Type: ${response.header("content-type")}")
-      println(s"Body: ${response.body}")
+        val response: HttpResponse = client.send(request)
+        println(s"Status: ${response.status}")
+        println(s"Content-Type: ${response.header("content-type")}")
+        println(s"Body: ${response.body}")
+      }
     }
   }
 }

--- a/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/HttpRequest.scala
+++ b/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/HttpRequest.scala
@@ -1,6 +1,7 @@
 package in.rcard.yaes.http.client
 
 import in.rcard.yaes.http.core.{BodyCodec, Headers, Method}
+import java.util.Locale
 import scala.concurrent.duration.Duration
 
 /** HTTP request representation for the client.
@@ -72,14 +73,14 @@ object HttpRequest:
   extension (req: HttpRequest)
     /** Adds or replaces a header. The key is lowercased for consistency. */
     def header(name: String, value: String): HttpRequest =
-      req.copy(headers = req.headers + (name.toLowerCase -> value))
+      req.copy(headers = req.headers + (name.toLowerCase(Locale.ROOT) -> value))
     /** Appends a query parameter. Duplicate keys are allowed. */
     def queryParam(name: String, value: String): HttpRequest =
       req.copy(queryParams = req.queryParams :+ (name, value))
     /** Sets the per-request timeout, overriding any previous value.
       *
-      * Infinite or undefined durations are treated as "no timeout" and leave the field unchanged.
+      * Non-finite or non-positive durations clear any previously set timeout (i.e. no timeout).
       */
     def timeout(duration: Duration): HttpRequest =
-      if duration.isFinite then req.copy(timeout = Some(duration))
-      else req
+      if duration.isFinite && duration.toMillis > 0 then req.copy(timeout = Some(duration))
+      else req.copy(timeout = None)

--- a/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/HttpResponse.scala
+++ b/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/HttpResponse.scala
@@ -2,6 +2,7 @@ package in.rcard.yaes.http.client
 
 import in.rcard.yaes.*
 import in.rcard.yaes.http.core.{BodyCodec, DecodingError}
+import java.util.Locale
 
 /** HTTP response returned by [[YaesClient.send]].
   *
@@ -32,7 +33,7 @@ extension (resp: HttpResponse)
     * @return the header value, or `None` if absent
     */
   def header(name: String): Option[String] =
-    resp.headers.get(name.toLowerCase)
+    resp.headers.get(name.toLowerCase(Locale.ROOT))
 
   /** Decodes the response body into a typed value.
     *

--- a/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/Uri.scala
+++ b/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/Uri.scala
@@ -50,12 +50,16 @@ object Uri:
     /** Returns the host component, if present. */
     def host: Option[String] = Option(uri.getHost)
 
-    /** Returns the port, defaulting to 80 if not specified. */
-    def port: Int = if uri.getPort == -1 then 80 else uri.getPort
+    /** Returns the port, defaulting to 443 for `https` and 80 for other schemes if not specified. */
+    def port: Int =
+      if uri.getPort != -1 then uri.getPort
+      else if uri.getScheme == "https" then 443
+      else 80
 
     /** Appends query parameters to the URI, URL-encoding keys and values.
       *
       * If the URI already contains a query string, parameters are appended with `&`.
+      * Existing fragment components are preserved correctly.
       *
       * @param queryParams the parameters to append
       * @return a [[java.net.URI]] with the appended query string
@@ -66,6 +70,5 @@ object Uri:
         val encoded = queryParams.map { (k, v) =>
           URLEncoder.encode(k, UTF_8) + "=" + URLEncoder.encode(v, UTF_8)
         }.mkString("&")
-        val base      = uri.value
-        val separator = if base.contains("?") then "&" else "?"
-        URI(base + separator + encoded)
+        val newQuery = Option(uri.getQuery).fold(encoded)(q => q + "&" + encoded)
+        new URI(uri.getScheme, uri.getAuthority, uri.getPath, newQuery, uri.getFragment)

--- a/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/YaesClient.scala
+++ b/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/YaesClient.scala
@@ -4,6 +4,7 @@ import in.rcard.yaes.*
 import java.net.http.{HttpClient => JHttpClient, HttpRequest => JHttpRequest, HttpResponse => JHttpResponse}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.{Duration => JDuration}
+import java.util.Locale
 import scala.jdk.CollectionConverters.*
 
 /** Effect-based HTTP client built on Java's [[java.net.http.HttpClient]].
@@ -44,13 +45,13 @@ class YaesClient private (private[client] val underlying: JHttpClient):
         .uri(javaUri)
         .method(request.method.toString, bodyPublisher)
       request.headers.foreach((k, v) => jReqBuilder.header(k, v))
-      request.timeout.foreach(d =>
+      request.timeout.filter(_.toMillis > 0).foreach(d =>
         jReqBuilder.timeout(JDuration.ofMillis(d.toMillis))
       )
       val jReq = jReqBuilder.build()
       val jResp = underlying.send(jReq, JHttpResponse.BodyHandlers.ofString())
       val headers = jResp.headers().map().asScala.map { (k, vs) =>
-        k.toLowerCase -> vs.asScala.headOption.getOrElse("")
+        k.toLowerCase(Locale.ROOT) -> vs.asScala.mkString(", ")
       }.toMap
       HttpResponse(jResp.statusCode(), headers, jResp.body())
     catch
@@ -80,7 +81,7 @@ object YaesClient:
     */
   def make(config: YaesClientConfig = YaesClientConfig())(using Resource): YaesClient =
     val builder = JHttpClient.newBuilder()
-    config.connectTimeout.filter(_.isFinite).foreach(d =>
+    config.connectTimeout.filter(d => d.isFinite && d.toMillis > 0).foreach(d =>
       builder.connectTimeout(JDuration.ofMillis(d.toMillis))
     )
     builder.followRedirects(config.followRedirects.toJava)

--- a/yaes-http/client/src/test/scala/in/rcard/yaes/http/client/YaesClientSendSpec.scala
+++ b/yaes-http/client/src/test/scala/in/rcard/yaes/http/client/YaesClientSendSpec.scala
@@ -187,7 +187,7 @@ class YaesClientSendSpec extends AnyFlatSpec with Matchers:
 
   it should "raise RequestTimeout when per-request timeout exceeded" in {
     val (server, baseUrl) = TestServer.start { exchange =>
-      Thread.sleep(2000)
+      Thread.sleep(500)
       exchange.sendResponseHeaders(200, 0)
       exchange.close()
     }


### PR DESCRIPTION
Add core and client subprojects under yaes-http/, update server and circe
to depend on core, and update yaes-http aggregate to include all modules.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>