### PR TITLE
feat(230,231): accumulate decoding errors + add Random.nextUuid

### DIFF
--- a/website/src/content/docs/http/circe.md
+++ b/website/src/content/docs/http/circe.md
@@ -12,7 +12,7 @@ JSON body codec integration for the λÆS HTTP server using [Circe](https://circ
 - **Automatic BodyCodec derivation** - Any type with Circe `Encoder` and `Decoder` gets a `BodyCodec` for free
 - **Compact JSON encoding** - Values are serialized using `asJson.noSpaces`
 - **Content-Type handling** - Automatically sets `Content-Type: application/json`
-- **Error mapping** - Circe `ParsingFailure` maps to `DecodingError.ParseError`, `DecodingFailure` maps to `DecodingError.ValidationError`
+- **Accumulating error mapping** - Decoding raises a non-empty `List[DecodingError]` accumulating all failures; Circe `ParsingFailure` maps to `DecodingError.ParseError`, each `DecodingFailure` maps to `DecodingError.ValidationError`
 
 **Requirements:**
 - Java 25+ (for Virtual Threads and Structured Concurrency)
@@ -100,7 +100,7 @@ This instance implements the three methods of the `BodyCodec` trait:
 |---|---|
 | `contentType` | Returns `"application/json"` |
 | `encode(value: A)` | Serializes using `value.asJson.noSpaces` (compact JSON) |
-| `decode(body: String)` | Parses using Circe's `decode[A]`, raising `DecodingError.ParseError` for invalid JSON syntax or `DecodingError.ValidationError` for schema mismatches |
+| `decode(body: String)` | Parses using Circe's `decodeAccumulating[A]`, raising a non-empty `List[DecodingError]`: `DecodingError.ParseError` for invalid JSON syntax, or one `DecodingError.ValidationError` per accumulated schema mismatch |
 
 Because the instance is parameterized over `A`, it works for **any** type with the required Circe typeclasses — no per-type boilerplate is needed.
 

--- a/website/src/content/docs/http/circe.md
+++ b/website/src/content/docs/http/circe.md
@@ -70,8 +70,8 @@ Sync.runBlocking(Duration.Inf) {
           Raise.fold {
             val user = req.as[User]
             Response.created(user)
-          } { case error: DecodingError =>
-            Response.badRequest(error.message)
+          } { case errors: List[DecodingError] =>
+            Response.badRequest(errors.map(_.message).mkString(", "))
           }
         }
       )
@@ -150,15 +150,15 @@ codec.encode(Person("Alice", Address("123 Main St", "Springfield")))
 
 ## Error Handling
 
-When JSON decoding fails, the codec raises the appropriate `DecodingError` variant. A `ParsingFailure` (invalid JSON syntax) becomes `DecodingError.ParseError` with the original exception attached, while a `DecodingFailure` (valid JSON but wrong shape) becomes `DecodingError.ValidationError`. Use `Raise.fold` to handle decoding errors in your routes:
+When JSON decoding fails, the codec raises a non-empty `List[DecodingError]` accumulating all errors found in the body. A `ParsingFailure` (invalid JSON syntax) becomes `DecodingError.ParseError` with the original exception attached, while each `DecodingFailure` (valid JSON but wrong shape) becomes `DecodingError.ValidationError`. Use `Raise.fold` to handle decoding errors in your routes:
 
 ```scala
 POST(p"/users") { req =>
   Raise.fold {
     val user = req.as[User]
     Response.created(user)
-  } { case error: DecodingError =>
-    Response.badRequest(error.message)
+  } { case errors: List[DecodingError] =>
+    Response.badRequest(errors.map(_.message).mkString(", "))
   }
 }
 ```
@@ -207,8 +207,8 @@ object JsonServer extends App {
               val newUser = req.as[CreateUser]
               val created = User(1, newUser.name, newUser.email)
               Response.created(created)
-            } { case error: DecodingError =>
-              Response.badRequest(error.message)
+            } { case errors: List[DecodingError] =>
+              Response.badRequest(errors.map(_.message).mkString(", "))
             }
           }
         )

--- a/website/src/content/docs/http/client.md
+++ b/website/src/content/docs/http/client.md
@@ -241,15 +241,15 @@ response.header("content-type")    // Option[String] (case-insensitive lookup)
 
 Use `response.as[A]` to decode the body into a typed value. This method:
 1. Checks the status code — raises `HttpError` for non-2xx
-2. Decodes the body — raises `DecodingError` if decoding fails
+2. Decodes the body — raises a non-empty `List[DecodingError]` if decoding fails
 
 ```scala
-Raise.run[HttpError | DecodingError] {
+Raise.run[HttpError | List[DecodingError]] {
   val body: String = response.as[String]
 }
 ```
 
-The union type `HttpError | DecodingError` makes both error types explicit in the effect signature.
+The union type `HttpError | List[DecodingError]` makes both error types explicit in the effect signature.
 
 ---
 
@@ -325,14 +325,14 @@ Raised by `response.as[A]` when the status code is outside the 2xx range. The er
 **Matching by error category:**
 
 ```scala
-val result = Raise.either[HttpError | DecodingError, String] {
+val result = Raise.either[HttpError | List[DecodingError], String] {
   response.as[String]
 }
 result match
-  case Left(e: ClientHttpError) => println(s"Client error ${e.status}: ${e.body}")
-  case Left(e: ServerHttpError) => println(s"Server error ${e.status}: ${e.body}")
-  case Left(e: DecodingError)   => println(s"Decoding failed: ${e.message}")
-  case Right(value)             => println(s"Success: $value")
+  case Left(e: ClientHttpError)          => println(s"Client error ${e.status}: ${e.body}")
+  case Left(e: ServerHttpError)          => println(s"Server error ${e.status}: ${e.body}")
+  case Left(errors: List[DecodingError]) => println(s"Decoding failed: ${errors.map(_.message).mkString(", ")}")
+  case Right(value)                      => println(s"Success: $value")
 ```
 
 ---
@@ -430,13 +430,13 @@ Raise.run[ConnectionError] {
       val response = client.send(request)
 
       // Decode the response with error handling
-      val result = Raise.either[HttpError | DecodingError, String] {
+      val result = Raise.either[HttpError | List[DecodingError], String] {
         response.as[String]
       }
       result match
-        case Left(e: HttpError)     => println(s"HTTP error ${e.status}")
-        case Left(e: DecodingError) => println(s"Decoding failed")
-        case Right(body)            => println(s"Response: $body")
+        case Left(e: HttpError)                => println(s"HTTP error ${e.status}")
+        case Left(errors: List[DecodingError]) => println(s"Decoding failed")
+        case Right(body)                       => println(s"Response: $body")
     }
   }
 }

--- a/website/src/content/docs/http/server.md
+++ b/website/src/content/docs/http/server.md
@@ -374,8 +374,8 @@ POST(p"/update") { req =>
   Raise.fold {
     val value = req.as[Int]  // Decode body to Int
     Response.ok(s"Received: $value")
-  } { case error: DecodingError =>
-    Response.badRequest(error.message)
+  } { case errors: List[DecodingError] =>
+    Response.badRequest(errors.map(_.message).mkString(", "))
   }
 }
 ```
@@ -388,7 +388,7 @@ Implement the `BodyCodec[A]` trait for custom types:
 trait BodyCodec[A] {
   def contentType: String  // Content-Type header value
   def encode(value: A): String
-  def decode(body: String): A raises DecodingError
+  def decode(body: String): A raises List[DecodingError]
 }
 ```
 
@@ -410,9 +410,9 @@ given userCodec: BodyCodec[User] with {
   def encode(user: User): String =
     user.asJson.noSpaces  // Using circe encoder
 
-  def decode(body: String): User raises DecodingError =
+  def decode(body: String): User raises List[DecodingError] =
     decode[User](body).fold(
-      error => Raise.raise(DecodingError(error.getMessage)),
+      error => Raise.raise(List(DecodingError.ParseError(error.getMessage))),
       user => user
     )
 }
@@ -422,8 +422,8 @@ POST(p"/users") { req =>
   Raise.fold {
     val user = req.as[User]
     Response.created(user)  // Content-Type: application/json set automatically
-  } { case error: DecodingError =>
-    Response.badRequest(error.message)
+  } { case errors: List[DecodingError] =>
+    Response.badRequest(errors.map(_.message).mkString(", "))
   }
 }
 ```

--- a/yaes-http/circe/README.md
+++ b/yaes-http/circe/README.md
@@ -68,7 +68,7 @@ The module provides a single `given` instance:
 given circeBodyCodec[A](using Encoder[A], Decoder[A]): BodyCodec[A]
 ```
 
-For any type `A` with both a Circe `Encoder` and `Decoder` in scope, a `BodyCodec[A]` is automatically derived. Decoding errors are returned as a non-empty `List[DecodingError]`, so all failures found in a single body are surfaced together. This codec:
+For any type `A` with both a Circe `Encoder` and `Decoder` in scope, a `BodyCodec[A]` is automatically derived. Decoding errors are raised as a non-empty `List[DecodingError]`, so all failures found in a single body are surfaced together. This codec:
 
 - **Encodes** values as compact JSON using `asJson.noSpaces`
 - **Sets** the `Content-Type` header to `application/json`

--- a/yaes-http/circe/README.md
+++ b/yaes-http/circe/README.md
@@ -49,8 +49,8 @@ Shutdown.run {
         Raise.fold {
           val user = req.as[User]
           Response.created(user)
-        } { case error: DecodingError =>
-          Response.badRequest(error.message)
+        } { case errors: List[DecodingError] =>
+          Response.badRequest(errors.map(_.message).mkString(", "))
         }
       }
     )
@@ -68,7 +68,7 @@ The module provides a single `given` instance:
 given circeBodyCodec[A](using Encoder[A], Decoder[A]): BodyCodec[A]
 ```
 
-For any type `A` with both a Circe `Encoder` and `Decoder` in scope, a `BodyCodec[A]` is automatically derived. This codec:
+For any type `A` with both a Circe `Encoder` and `Decoder` in scope, a `BodyCodec[A]` is automatically derived. Decoding errors are returned as a non-empty `List[DecodingError]`, so all failures found in a single body are surfaced together. This codec:
 
 - **Encodes** values as compact JSON using `asJson.noSpaces`
 - **Sets** the `Content-Type` header to `application/json`
@@ -110,15 +110,15 @@ codec.encode(Person("Alice", Address("123 Main St", "Springfield")))
 
 ## Error Handling
 
-When JSON decoding fails, the codec raises a `DecodingError.ParseError` containing the original Circe error message and exception. Use `Raise.fold` to handle decoding errors in routes:
+When JSON decoding fails, the codec raises a non-empty `List[DecodingError]` accumulating all errors found in the body. Use `Raise.fold` to handle decoding errors in routes:
 
 ```scala
 POST(p"/users") { req =>
   Raise.fold {
     val user = req.as[User]
     Response.created(user)
-  } { case error: DecodingError =>
-    Response.badRequest(error.message)
+  } { case errors: List[DecodingError] =>
+    Response.badRequest(errors.map(_.message).mkString(", "))
   }
 }
 ```

--- a/yaes-http/circe/src/main/scala/in/rcard/yaes/http/circe/CirceCodec.scala
+++ b/yaes-http/circe/src/main/scala/in/rcard/yaes/http/circe/CirceCodec.scala
@@ -57,7 +57,7 @@ given circeBodyCodec[A](using encoder: Encoder[A], decoder: Decoder[A]): BodyCod
       case Validated.Valid(a) => a
       case Validated.Invalid(errs) =>
         Raise.raise(errs.toList.map {
-          case pf: ParsingFailure  => DecodingError.ParseError(pf.getMessage, Some(pf))
+          case pf: ParsingFailure  => DecodingError.ParseError(pf.getMessage, Option(pf.underlying))
           case df: DecodingFailure => DecodingError.ValidationError(df.getMessage)
         })
     }

--- a/yaes-http/circe/src/main/scala/in/rcard/yaes/http/circe/CirceCodec.scala
+++ b/yaes-http/circe/src/main/scala/in/rcard/yaes/http/circe/CirceCodec.scala
@@ -3,23 +3,25 @@ package in.rcard.yaes.http.circe
 import in.rcard.yaes.*
 import in.rcard.yaes.http.core.{BodyCodec, DecodingError}
 import io.circe.{Encoder, Decoder, ParsingFailure, DecodingFailure}
+import io.circe.parser.decodeAccumulating as circeDecodeAccumulating
 import io.circe.syntax.*
-import io.circe.parser.decode as circeDecode
+import cats.data.Validated
 
-/** 
+/**
  * Default `BodyCodec` instance for any type `A` that has both a Circe [[io.circe.Encoder]]
  * and [[io.circe.Decoder]] in scope.
  *
  * This codec:
  *   - Encodes values of type `A` as compact JSON using Circe (`asJson.noSpaces`).
  *   - Sets the HTTP `Content-Type` header to `application/json`.
- *   - Decodes JSON bodies using Circe's `decode`, mapping failures to:
+ *   - Decodes JSON bodies using Circe's `decodeAccumulating`, mapping all failures to a
+ *     non-empty `List[DecodingError]`:
  *     - If Circe returns a [[io.circe.ParsingFailure]] (invalid JSON syntax), it is mapped to
  *       [[in.rcard.yaes.http.core.DecodingError.ParseError]] with the original message and
  *       exception attached.
- *     - If Circe returns a [[io.circe.DecodingFailure]] (valid JSON but wrong shape, e.g. missing
- *       fields), it is mapped to [[in.rcard.yaes.http.core.DecodingError.ValidationError]]
- *       with the original message.
+ *     - If Circe returns [[io.circe.DecodingFailure]] errors (valid JSON but wrong shape, e.g.
+ *       missing fields), each is mapped to
+ *       [[in.rcard.yaes.http.core.DecodingError.ValidationError]] with the original message.
  * Usage:
  * {{{
  *   import io.circe.{Encoder, Decoder}
@@ -32,7 +34,7 @@ import io.circe.parser.decode as circeDecode
  *
  *   // `circeBodyCodec` provides an implicit BodyCodec[MyPayload]
  *   def handleBody(body: String)(using codec: BodyCodec[MyPayload]) = {
- *     val decoded: MyPayload raises DecodingError = codec.decode(body)
+ *     val decoded: MyPayload raises List[DecodingError] = codec.decode(body)
  *   }
  * }}}
  *
@@ -41,21 +43,22 @@ import io.circe.parser.decode as circeDecode
  *   - If Circe returns a [[io.circe.ParsingFailure]] (invalid JSON syntax), it is mapped to
  *     [[in.rcard.yaes.http.core.DecodingError.ParseError]] with the original message and
  *     exception attached.
- *   - If Circe returns a [[io.circe.DecodingFailure]] (valid JSON but wrong shape, e.g. missing
- *     fields), it is mapped to [[in.rcard.yaes.http.core.DecodingError.ValidationError]]
- *     with the original message.
+ *   - If Circe returns [[io.circe.DecodingFailure]] errors (valid JSON but wrong shape, e.g.
+ *     missing fields), each is mapped to
+ *     [[in.rcard.yaes.http.core.DecodingError.ValidationError]] with the original message.
  */
 given circeBodyCodec[A](using encoder: Encoder[A], decoder: Decoder[A]): BodyCodec[A] with {
   def contentType: String = "application/json"
 
   def encode(value: A): String = value.asJson.noSpaces
 
-  def decode(body: String): A raises DecodingError =
-    circeDecode[A](body) match {
-      case Right(value) => value
-      case Left(error: ParsingFailure) =>
-        Raise.raise(DecodingError.ParseError(error.getMessage, Some(error)))
-      case Left(error: DecodingFailure) =>
-        Raise.raise(DecodingError.ValidationError(error.getMessage))
+  def decode(body: String): A raises List[DecodingError] =
+    circeDecodeAccumulating[A](body) match {
+      case Validated.Valid(a) => a
+      case Validated.Invalid(errs) =>
+        Raise.raise(errs.toList.map {
+          case pf: ParsingFailure  => DecodingError.ParseError(pf.getMessage, Some(pf))
+          case df: DecodingFailure => DecodingError.ValidationError(df.getMessage)
+        })
     }
 }

--- a/yaes-http/circe/src/test/scala/in/rcard/yaes/http/circe/CirceCodecSpec.scala
+++ b/yaes-http/circe/src/test/scala/in/rcard/yaes/http/circe/CirceCodecSpec.scala
@@ -29,21 +29,37 @@ class CirceCodecSpec extends AnyFlatSpec with Matchers {
 
   it should "raise ParseError for malformed JSON" in {
     val codec = summon[BodyCodec[User]]
-    val result = Raise.either {
+    val result = Raise.either[List[DecodingError], User] {
       codec.decode("not json at all")
     }
     result.isLeft shouldBe true
-    result.left.get shouldBe a[DecodingError.ParseError]
-    result.left.get.asInstanceOf[DecodingError.ParseError].cause shouldBe defined
+    result.left.get.head shouldBe a[DecodingError.ParseError]
+    result.left.get.head.asInstanceOf[DecodingError.ParseError].cause shouldBe defined
   }
 
   it should "raise ValidationError for JSON with missing fields" in {
     val codec = summon[BodyCodec[User]]
-    val result = Raise.either {
+    val result = Raise.either[List[DecodingError], User] {
       codec.decode("""{"name":"Alice"}""")
     }
     result.isLeft shouldBe true
-    result.left.get shouldBe a[DecodingError.ValidationError]
+    result.left.get.head shouldBe a[DecodingError.ValidationError]
+  }
+
+  it should "accumulate multiple decoding errors" in {
+    case class Person(name: String, age: Int)
+    given io.circe.Decoder[Person] = io.circe.Decoder.forProduct2("name", "age")(Person.apply)
+    given io.circe.Encoder[Person] = io.circe.Encoder.forProduct2("name", "age")(p => (p.name, p.age))
+    val codec = summon[BodyCodec[Person]]
+
+    val result = Raise.either[List[DecodingError], Person] {
+      codec.decode("""{"age":"not-an-int"}""")
+    }
+
+    result.isLeft shouldBe true
+    val errors = result.left.toOption.get
+    errors.size should be >= 2
+    errors.collect { case DecodingError.ValidationError(msg) => msg }.size shouldBe errors.size
   }
 
   it should "have content type application/json" in {

--- a/yaes-http/client/README.md
+++ b/yaes-http/client/README.md
@@ -200,10 +200,10 @@ response.header("content-type")    // Option[String] (case-insensitive)
 
 ### Typed Decoding
 
-Use `response.as[A]` to decode the body into a typed value. This raises `HttpError` for non-2xx status codes and `DecodingError` if decoding fails:
+Use `response.as[A]` to decode the body into a typed value. This raises `HttpError` for non-2xx status codes and a non-empty `List[DecodingError]` if decoding fails:
 
 ```scala
-Raise.run[HttpError | DecodingError] {
+Raise.run[HttpError | List[DecodingError]] {
   val user: String = response.as[String]
 }
 ```
@@ -272,14 +272,14 @@ Raised by `response.as[A]` when the status code is outside 2xx:
 Use the `ClientHttpError` and `ServerHttpError` marker traits to match error categories:
 
 ```scala
-val result = Raise.either[HttpError | DecodingError, String] {
+val result = Raise.either[HttpError | List[DecodingError], String] {
   response.as[String]
 }
 result match
-  case Left(e: ClientHttpError) => println(s"Client error ${e.status}: ${e.body}")
-  case Left(e: ServerHttpError) => println(s"Server error ${e.status}: ${e.body}")
-  case Left(e: DecodingError)   => println(s"Decoding failed: ${e.message}")
-  case Right(value)             => println(s"Success: $value")
+  case Left(e: ClientHttpError)          => println(s"Client error ${e.status}: ${e.body}")
+  case Left(e: ServerHttpError)          => println(s"Server error ${e.status}: ${e.body}")
+  case Left(errors: List[DecodingError]) => println(s"Decoding failed: ${errors.map(_.message).mkString(", ")}")
+  case Right(value)                      => println(s"Success: $value")
 ```
 
 ## URI Validation
@@ -351,13 +351,13 @@ Raise.run[ConnectionError] {
 
       val response = client.send(request)
 
-      val result = Raise.either[HttpError | DecodingError, String] {
+      val result = Raise.either[HttpError | List[DecodingError], String] {
         response.as[String]
       }
       result match
-        case Left(e: HttpError)    => println(s"HTTP error ${e.status}")
-        case Left(e: DecodingError) => println(s"Decoding failed")
-        case Right(body)           => println(s"Response: $body")
+        case Left(e: HttpError)                => println(s"HTTP error ${e.status}")
+        case Left(errors: List[DecodingError]) => println(s"Decoding failed")
+        case Right(body)                       => println(s"Response: $body")
     }
   }
 }

--- a/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/HttpError.scala
+++ b/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/HttpError.scala
@@ -8,7 +8,7 @@ package in.rcard.yaes.http.client
   *
   * Example:
   * {{{
-  * val result = Raise.either[HttpError | DecodingError, User] {
+  * val result = Raise.either[HttpError | List[DecodingError], User] {
   *   response.as[User]
   * }
   * result match

--- a/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/HttpResponse.scala
+++ b/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/HttpResponse.scala
@@ -13,7 +13,7 @@ import java.util.Locale
   * {{{
   * val resp: HttpResponse = client.send(request)
   * resp.header("content-type")  // Option[String]
-  * resp.as[User]                // User raises (HttpError | DecodingError)
+  * resp.as[User]                // User raises (HttpError | List[DecodingError])
   * }}}
   *
   * @param status  the HTTP status code
@@ -38,12 +38,12 @@ extension (resp: HttpResponse)
   /** Decodes the response body into a typed value.
     *
     * Raises [[HttpError]] for non-2xx status codes (checked before decoding).
-    * Raises [[DecodingError]] if the body cannot be decoded by the codec.
+    * Raises a non-empty `List[DecodingError]` if the body cannot be decoded by the codec.
     *
     * @tparam A the target type
     * @return the decoded value
     */
-  def as[A](using codec: BodyCodec[A]): A raises (HttpError | DecodingError) =
+  def as[A](using codec: BodyCodec[A]): A raises (HttpError | List[DecodingError]) =
     if resp.status < 200 || resp.status >= 300 then
       Raise.raise(HttpError.fromStatus(resp.status, resp.body))
     else

--- a/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/YaesClient.scala
+++ b/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/YaesClient.scala
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters.*
   * Resource.run {
   *   val client = YaesClient.make()
   *   val resp = client.send(HttpRequest.get(uri))  // HttpResponse
-  *   resp.as[User]                                  // User raises (HttpError | DecodingError)
+  *   resp.as[User]                                  // User raises (HttpError | List[DecodingError])
   * }
   * }}}
   */

--- a/yaes-http/client/src/test/scala/in/rcard/yaes/http/client/HttpResponseSpec.scala
+++ b/yaes-http/client/src/test/scala/in/rcard/yaes/http/client/HttpResponseSpec.scala
@@ -21,54 +21,54 @@ class HttpResponseSpec extends AnyFlatSpec with Matchers:
 
   "HttpResponse.as" should "decode 200 body via BodyCodec" in {
     val resp = HttpResponse(200,Map.empty, "42")
-    val result = Raise.either[HttpError | DecodingError, Int] { resp.as[Int] }
+    val result = Raise.either[HttpError | List[DecodingError], Int] { resp.as[Int] }
     result shouldBe Right(42)
   }
 
   it should "decode 201 body (any 2xx)" in {
     val resp = HttpResponse(201,Map.empty, "99")
-    val result = Raise.either[HttpError | DecodingError, Int] { resp.as[Int] }
+    val result = Raise.either[HttpError | List[DecodingError], Int] { resp.as[Int] }
     result shouldBe Right(99)
   }
 
   it should "raise UnexpectedStatus for 301 (non-2xx)" in {
     val resp = HttpResponse(301,Map.empty, "moved")
-    val result = Raise.either[HttpError | DecodingError, Int] { resp.as[Int] }
+    val result = Raise.either[HttpError | List[DecodingError], Int] { resp.as[Int] }
     result shouldBe Left(HttpError.UnexpectedStatus(301, "moved"))
   }
 
   it should "raise NotFound for 404" in {
     val resp = HttpResponse(404,Map.empty, "not found")
-    val result = Raise.either[HttpError | DecodingError, Int] { resp.as[Int] }
+    val result = Raise.either[HttpError | List[DecodingError], Int] { resp.as[Int] }
     result shouldBe Left(HttpError.NotFound("not found"))
   }
 
   it should "raise InternalServerError for 500" in {
     val resp = HttpResponse(500,Map.empty, "fail")
-    val result = Raise.either[HttpError | DecodingError, Int] { resp.as[Int] }
+    val result = Raise.either[HttpError | List[DecodingError], Int] { resp.as[Int] }
     result shouldBe Left(HttpError.InternalServerError("fail"))
   }
 
   it should "raise OtherClientError for 418" in {
     val resp = HttpResponse(418,Map.empty, "teapot")
-    val result = Raise.either[HttpError | DecodingError, Int] { resp.as[Int] }
+    val result = Raise.either[HttpError | List[DecodingError], Int] { resp.as[Int] }
     result shouldBe Left(HttpError.OtherClientError(418, "teapot"))
   }
 
-  it should "raise DecodingError for invalid body on 200" in {
+  it should "raise List[DecodingError] for invalid body on 200" in {
     val resp = HttpResponse(200,Map.empty, "not-a-number")
-    val result = Raise.either[HttpError | DecodingError, Int] { resp.as[Int] }
-    result.left.getOrElse(fail()) shouldBe a[DecodingError]
+    val result = Raise.either[HttpError | List[DecodingError], Int] { resp.as[Int] }
+    result shouldBe Left(List(DecodingError.ParseError("Invalid integer: not-a-number")))
   }
 
-  it should "raise DecodingError for empty body on 200" in {
+  it should "raise List[DecodingError] for empty body on 200" in {
     val resp = HttpResponse(200,Map.empty, "")
-    val result = Raise.either[HttpError | DecodingError, Int] { resp.as[Int] }
-    result.left.getOrElse(fail()) shouldBe a[DecodingError]
+    val result = Raise.either[HttpError | List[DecodingError], Int] { resp.as[Int] }
+    result shouldBe Left(List(DecodingError.ParseError("Invalid integer: ")))
   }
 
   it should "raise HttpError for 404 without attempting decode" in {
     val resp = HttpResponse(404,Map.empty, "not valid as int either")
-    val result = Raise.either[HttpError | DecodingError, Int] { resp.as[Int] }
+    val result = Raise.either[HttpError | List[DecodingError], Int] { resp.as[Int] }
     result shouldBe Left(HttpError.NotFound("not valid as int either"))
   }

--- a/yaes-http/client/src/test/scala/in/rcard/yaes/http/client/YaesClientIntegrationSpec.scala
+++ b/yaes-http/client/src/test/scala/in/rcard/yaes/http/client/YaesClientIntegrationSpec.scala
@@ -19,16 +19,16 @@ class YaesClientIntegrationSpec extends AnyFlatSpec with Matchers:
   private def sendAndDecode[A](client: YaesClient, request: HttpRequest)(using
       BodyCodec[A],
       Sync
-  ): Either[ConnectionError | HttpError | DecodingError, A] =
+  ): Either[ConnectionError | HttpError | List[DecodingError], A] =
     Raise
       .either[ConnectionError, HttpResponse] { client.send(request) }
       .left
-      .map(e => e: ConnectionError | HttpError | DecodingError)
+      .map(e => e: ConnectionError | HttpError | List[DecodingError])
       .flatMap { resp =>
         Raise
-          .either[HttpError | DecodingError, A] { resp.as[A] }
+          .either[HttpError | List[DecodingError], A] { resp.as[A] }
           .left
-          .map(e => e: ConnectionError | HttpError | DecodingError)
+          .map(e => e: ConnectionError | HttpError | List[DecodingError])
       }
 
   "YaesClient full pipeline" should "GET and decode response body" in {
@@ -124,7 +124,7 @@ class YaesClientIntegrationSpec extends AnyFlatSpec with Matchers:
           sendAndDecode[Int](client, HttpRequest.get(uri(baseUrl)))
         }
       }
-      result.get.left.getOrElse(fail()) shouldBe a[DecodingError]
+      result.get.left.getOrElse(fail()) shouldBe List(DecodingError.ParseError("Invalid integer: not-a-number"))
     finally server.stop(0)
   }
 

--- a/yaes-http/core/src/main/scala/in/rcard/yaes/http/core/BodyCodec.scala
+++ b/yaes-http/core/src/main/scala/in/rcard/yaes/http/core/BodyCodec.scala
@@ -14,7 +14,7 @@ import in.rcard.yaes.*
   * given BodyCodec[User] with {
   *   def contentType: String = "application/json"
   *   def encode(user: User): String = s"""{"name":"${user.name}","age":${user.age}}"""
-  *   def decode(body: String): User raises DecodingError = {
+  *   def decode(body: String): User raises List[DecodingError] = {
   *     // JSON parsing logic
   *     ???
   *   }
@@ -34,8 +34,8 @@ trait BodyCodec[A] {
   /** Encode a value to a string representation */
   def encode(value: A): String
 
-  /** Decode a string body to a value, raising DecodingError on failure */
-  def decode(body: String): A raises DecodingError
+  /** Decode a string body to a value, raising a non-empty `List[DecodingError]` on failure. The list aggregates every error found during decoding; implementations MUST NOT raise an empty list. */
+  def decode(body: String): A raises List[DecodingError]
 }
 
 object BodyCodec {
@@ -43,7 +43,7 @@ object BodyCodec {
   given BodyCodec[String] with {
     def contentType: String = "text/plain; charset=UTF-8"
     def encode(value: String): String = value
-    def decode(body: String): String raises DecodingError = body
+    def decode(body: String): String raises List[DecodingError] = body
   }
 
   /** Built-in codec for Int (text/plain) */
@@ -52,11 +52,11 @@ object BodyCodec {
 
     def encode(value: Int): String = value.toString
 
-    def decode(body: String): Int raises DecodingError =
+    def decode(body: String): Int raises List[DecodingError] =
       body.toIntOption match {
         case Some(i) => i
         case None =>
-          Raise.raise(DecodingError.ParseError(s"Invalid integer: $body"))
+          Raise.raise(List(DecodingError.ParseError(s"Invalid integer: $body")))
       }
   }
 
@@ -66,11 +66,11 @@ object BodyCodec {
 
     def encode(value: Long): String = value.toString
 
-    def decode(body: String): Long raises DecodingError =
+    def decode(body: String): Long raises List[DecodingError] =
       body.toLongOption match {
         case Some(l) => l
         case None =>
-          Raise.raise(DecodingError.ParseError(s"Invalid long: $body"))
+          Raise.raise(List(DecodingError.ParseError(s"Invalid long: $body")))
       }
   }
 
@@ -80,11 +80,11 @@ object BodyCodec {
 
     def encode(value: Double): String = value.toString
 
-    def decode(body: String): Double raises DecodingError =
+    def decode(body: String): Double raises List[DecodingError] =
       body.toDoubleOption match {
         case Some(d) => d
         case None =>
-          Raise.raise(DecodingError.ParseError(s"Invalid double: $body"))
+          Raise.raise(List(DecodingError.ParseError(s"Invalid double: $body")))
       }
   }
 
@@ -94,11 +94,11 @@ object BodyCodec {
 
     def encode(value: Boolean): String = value.toString
 
-    def decode(body: String): Boolean raises DecodingError =
+    def decode(body: String): Boolean raises List[DecodingError] =
       body.toBooleanOption match {
         case Some(b) => b
         case None =>
-          Raise.raise(DecodingError.ParseError(s"Invalid boolean: $body"))
+          Raise.raise(List(DecodingError.ParseError(s"Invalid boolean: $body")))
       }
   }
 }

--- a/yaes-http/server/README.md
+++ b/yaes-http/server/README.md
@@ -338,7 +338,7 @@ This ensures graceful shutdown even when the process is killed.
 
 ## Body Codecs (JSON, etc.)
 
-The server uses the `BodyCodec[A]` typeclass for automatic body encoding/decoding. Built-in codecs exist for `String`, `Int`, `Long`, `Double`, and `Boolean`.
+The server uses the `BodyCodec[A]` typeclass for automatic body encoding/decoding. Built-in codecs exist for `String`, `Int`, `Long`, `Double`, and `Boolean`. Decoding errors are returned as a non-empty `List[DecodingError]`, so all failures found in a single body are surfaced together.
 
 ```scala
 // Built-in codecs work automatically
@@ -369,9 +369,9 @@ case class User(id: Int, name: String)
 given BodyCodec[User] with {
   def contentType: String = "application/json"
   def encode(user: User): String = user.asJson.noSpaces
-  def decode(body: String): User raises DecodingError =
+  def decode(body: String): User raises List[DecodingError] =
     decode[User](body).fold(
-      error => Raise.raise(DecodingError(error.getMessage)),
+      error => Raise.raise(List(DecodingError.ParseError(error.getMessage))),
       user => user
     )
 }
@@ -386,8 +386,8 @@ POST(p"/users") { req =>
   Raise.fold {
     val user = req.as[User]  // Automatically decoded from JSON
     Response.created(user)
-  } { case error: DecodingError =>
-    Response.badRequest(error.message)
+  } { case errors: List[DecodingError] =>
+    Response.badRequest(errors.map(_.message).mkString(", "))
   }
 }
 ```

--- a/yaes-http/server/README.md
+++ b/yaes-http/server/README.md
@@ -338,7 +338,7 @@ This ensures graceful shutdown even when the process is killed.
 
 ## Body Codecs (JSON, etc.)
 
-The server uses the `BodyCodec[A]` typeclass for automatic body encoding/decoding. Built-in codecs exist for `String`, `Int`, `Long`, `Double`, and `Boolean`. Decoding errors are returned as a non-empty `List[DecodingError]`, so all failures found in a single body are surfaced together.
+The server uses the `BodyCodec[A]` typeclass for automatic body encoding/decoding. Built-in codecs exist for `String`, `Int`, `Long`, `Double`, and `Boolean`. Decoding failures are raised via `Raise[List[DecodingError]]`, so all failures found in a single body can be surfaced together.
 
 ```scala
 // Built-in codecs work automatically

--- a/yaes-http/server/src/main/scala/in/rcard/yaes/http/server/Request.scala
+++ b/yaes-http/server/src/main/scala/in/rcard/yaes/http/server/Request.scala
@@ -50,10 +50,10 @@ object Request {
       * Example:
       * {{{
       * // With a custom User codec in scope
-      * val user: User raises DecodingError = request.as[User]
+      * val user: User raises List[DecodingError] = request.as[User]
       *
-      * // In a handler that declares Raise[DecodingError]
-      * def handleCreateUser(req: Request): Response raises DecodingError = {
+      * // In a handler that declares Raise[List[DecodingError]]
+      * def handleCreateUser(req: Request): Response raises List[DecodingError] = {
       *   val user = req.as[User]
       *   // ... process user ...
       *   Response.created(user)
@@ -65,7 +65,7 @@ object Request {
       * @return
       *   The decoded value
       */
-    def as[A](using codec: BodyCodec[A]): A raises DecodingError =
+    def as[A](using codec: BodyCodec[A]): A raises List[DecodingError] =
       codec.decode(req.body)
 
     /** Get a header value by name (case-insensitive).

--- a/yaes-http/server/src/main/scala/in/rcard/yaes/http/server/Request.scala
+++ b/yaes-http/server/src/main/scala/in/rcard/yaes/http/server/Request.scala
@@ -45,7 +45,7 @@ object Request {
     /** Decode request body using the implicit codec.
       *
       * The codec is resolved automatically from the context using Scala 3's `using` clauses. Decoding
-      * failures are raised as typed errors via the `Raise[DecodingError]` effect.
+      * failures are raised as typed errors via the `Raise[List[DecodingError]]` effect.
       *
       * Example:
       * {{{

--- a/yaes-http/server/src/test/scala/in/rcard/yaes/http/server/BodyCodecSpec.scala
+++ b/yaes-http/server/src/test/scala/in/rcard/yaes/http/server/BodyCodecSpec.scala
@@ -33,7 +33,7 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
     result shouldBe Right(123)
   }
 
-  it should "raise DecodingError for invalid integers" in {
+  it should "raise List[DecodingError] for invalid integers" in {
     val codec = summon[BodyCodec[Int]]
     val result = Raise.either[List[DecodingError], Int] {
       codec.decode("not a number")
@@ -56,7 +56,7 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
     result shouldBe Right(987654321L)
   }
 
-  it should "raise DecodingError for invalid longs" in {
+  it should "raise List[DecodingError] for invalid longs" in {
     val codec = summon[BodyCodec[Long]]
     val result = Raise.either[List[DecodingError], Long] {
       codec.decode("not a long")
@@ -79,7 +79,7 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
     result shouldBe Right(2.718)
   }
 
-  it should "raise DecodingError for invalid doubles" in {
+  it should "raise List[DecodingError] for invalid doubles" in {
     val codec = summon[BodyCodec[Double]]
     val result = Raise.either[List[DecodingError], Double] {
       codec.decode("not a double")
@@ -107,7 +107,7 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
     resultFalse shouldBe Right(false)
   }
 
-  it should "raise DecodingError for invalid booleans" in {
+  it should "raise List[DecodingError] for invalid booleans" in {
     val codec = summon[BodyCodec[Boolean]]
     val result = Raise.either[List[DecodingError], Boolean] {
       codec.decode("not a boolean")
@@ -155,7 +155,7 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
     result shouldBe Right(User("Bob", 25))
   }
 
-  it should "raise DecodingError for invalid JSON" in {
+  it should "raise List[DecodingError] for invalid JSON" in {
     val codec = summon[BodyCodec[User]]
     val result = Raise.either[List[DecodingError], User] {
       codec.decode("""{"invalid":"json"}""")
@@ -164,7 +164,7 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
     result.left.get shouldBe List(DecodingError.ParseError("""Invalid User JSON: {"invalid":"json"}"""))
   }
 
-  it should "raise DecodingError for malformed JSON" in {
+  it should "raise List[DecodingError] for malformed JSON" in {
     val codec = summon[BodyCodec[User]]
     val result = Raise.either[List[DecodingError], User] {
       codec.decode("not json at all")

--- a/yaes-http/server/src/test/scala/in/rcard/yaes/http/server/BodyCodecSpec.scala
+++ b/yaes-http/server/src/test/scala/in/rcard/yaes/http/server/BodyCodecSpec.scala
@@ -35,11 +35,11 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
 
   it should "raise DecodingError for invalid integers" in {
     val codec = summon[BodyCodec[Int]]
-    val result = Raise.either {
+    val result = Raise.either[List[DecodingError], Int] {
       codec.decode("not a number")
     }
     result.isLeft shouldBe true
-    result.left.get shouldBe a[DecodingError.ParseError]
+    result.left.get shouldBe List(DecodingError.ParseError("Invalid integer: not a number"))
   }
 
   "BodyCodec[Long]" should "encode longs to strings" in {
@@ -58,11 +58,11 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
 
   it should "raise DecodingError for invalid longs" in {
     val codec = summon[BodyCodec[Long]]
-    val result = Raise.either {
+    val result = Raise.either[List[DecodingError], Long] {
       codec.decode("not a long")
     }
     result.isLeft shouldBe true
-    result.left.get shouldBe a[DecodingError.ParseError]
+    result.left.get shouldBe List(DecodingError.ParseError("Invalid long: not a long"))
   }
 
   "BodyCodec[Double]" should "encode doubles to strings" in {
@@ -81,11 +81,11 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
 
   it should "raise DecodingError for invalid doubles" in {
     val codec = summon[BodyCodec[Double]]
-    val result = Raise.either {
+    val result = Raise.either[List[DecodingError], Double] {
       codec.decode("not a double")
     }
     result.isLeft shouldBe true
-    result.left.get shouldBe a[DecodingError.ParseError]
+    result.left.get shouldBe List(DecodingError.ParseError("Invalid double: not a double"))
   }
 
   "BodyCodec[Boolean]" should "encode booleans to strings" in {
@@ -109,11 +109,11 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
 
   it should "raise DecodingError for invalid booleans" in {
     val codec = summon[BodyCodec[Boolean]]
-    val result = Raise.either {
+    val result = Raise.either[List[DecodingError], Boolean] {
       codec.decode("not a boolean")
     }
     result.isLeft shouldBe true
-    result.left.get shouldBe a[DecodingError.ParseError]
+    result.left.get shouldBe List(DecodingError.ParseError("Invalid boolean: not a boolean"))
   }
 
   // Custom codec for testing
@@ -125,7 +125,7 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
     def encode(user: User): String =
       s"""{"name":"${user.name}","age":${user.age}}"""
 
-    def decode(body: String): User raises DecodingError = {
+    def decode(body: String): User raises List[DecodingError] = {
       // Simple JSON parser for testing
       val namePattern = """"name":"([^"]+)"""".r
       val agePattern = """"age":(\d+)""".r
@@ -135,7 +135,7 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
 
       (nameOpt, ageOpt) match {
         case (Some(name), Some(age)) => User(name, age)
-        case _ => Raise.raise(DecodingError.ParseError(s"Invalid User JSON: $body"))
+        case _ => Raise.raise(List(DecodingError.ParseError(s"Invalid User JSON: $body")))
       }
     }
   }
@@ -157,19 +157,19 @@ class BodyCodecSpec extends AnyFlatSpec with Matchers {
 
   it should "raise DecodingError for invalid JSON" in {
     val codec = summon[BodyCodec[User]]
-    val result = Raise.either {
+    val result = Raise.either[List[DecodingError], User] {
       codec.decode("""{"invalid":"json"}""")
     }
     result.isLeft shouldBe true
-    result.left.get shouldBe a[DecodingError.ParseError]
+    result.left.get shouldBe List(DecodingError.ParseError("""Invalid User JSON: {"invalid":"json"}"""))
   }
 
   it should "raise DecodingError for malformed JSON" in {
     val codec = summon[BodyCodec[User]]
-    val result = Raise.either {
+    val result = Raise.either[List[DecodingError], User] {
       codec.decode("not json at all")
     }
     result.isLeft shouldBe true
-    result.left.get shouldBe a[DecodingError.ParseError]
+    result.left.get shouldBe List(DecodingError.ParseError("Invalid User JSON: not json at all"))
   }
 }


### PR DESCRIPTION
Closes #230

## Scope
- **#230** — `BodyCodec.decode` now raises `List[DecodingError]` so all body decoding failures surface together. Server `Request.as`, client `HttpResponse.as`, and the Circe codec (`decodeAccumulating`) updated accordingly.

Docs, READMEs, and tests updated for both.