### PR TITLE
fix: Raise.catching[E] uses isInstance instead of == for subclass matching

### DIFF
--- a/yaes-core/src/main/scala/in/rcard/yaes/Raise.scala
+++ b/yaes-core/src/main/scala/in/rcard/yaes/Raise.scala
@@ -421,7 +421,7 @@ object Raise {
       block
     } catch {
       case NonFatal(nfex) =>
-        if (nfex.getClass == E.runtimeClass) Raise.raise(nfex.asInstanceOf[E])
+        if (E.runtimeClass.isInstance(nfex)) Raise.raise(nfex.asInstanceOf[E])
         else throw nfex
       case ex => throw ex
     }

--- a/yaes-core/src/test/scala/in/rcard/yaes/RaiseSpec.scala
+++ b/yaes-core/src/test/scala/in/rcard/yaes/RaiseSpec.scala
@@ -350,6 +350,23 @@ class RaiseSpec extends AsyncFlatSpec with Matchers {
     }
   }
 
+  it should "catch subclasses of E" in {
+    val result = Raise.either[RuntimeException, Int] {
+      Raise.catching[RuntimeException, Int](throw new ArithmeticException("/ by zero"))
+    }
+    result match
+      case Left(ex) => ex shouldBe a[ArithmeticException]
+      case Right(_) => fail("expected Left")
+  }
+
+  it should "not catch sibling exceptions unrelated to E" in {
+    assertThrows[ArithmeticException] {
+      Raise.either[IllegalArgumentException, Int] {
+        Raise.catching[IllegalArgumentException, Int](throw new ArithmeticException("/ by zero"))
+      }
+    }
+  }
+
   "withError" should "return the value if it is not an error" in {
     val actual = Raise.either {
       Raise.withError[Int, String, Int](s => s.length) { 42 }
@@ -711,32 +728,6 @@ class RaiseSpec extends AsyncFlatSpec with Matchers {
     }
 
     result.left.map(_.toSet) should be(Left(Set("error2", "error4")))
-  }
-
-  it should "catch subclasses of E" in {
-    val result = Raise.either[RuntimeException, Int] {
-      Raise.catching[RuntimeException, Int](throw new ArithmeticException("/ by zero"))
-    }
-    result match
-      case Left(ex) => ex shouldBe a[ArithmeticException]
-      case Right(_) => fail("expected Left")
-  }
-
-  it should "catch exact class E" in {
-    val result = Raise.either[ArithmeticException, Int] {
-      Raise.catching[ArithmeticException, Int](throw new ArithmeticException("/ by zero"))
-    }
-    result match
-      case Left(ex) => ex shouldBe a[ArithmeticException]
-      case Right(_) => fail("expected Left")
-  }
-
-  it should "not catch sibling exceptions unrelated to E" in {
-    assertThrows[ArithmeticException] {
-      Raise.either[IllegalArgumentException, Int] {
-        Raise.catching[IllegalArgumentException, Int](throw new ArithmeticException("/ by zero"))
-      }
-    }
   }
 
   private def int(value: Int): Raise[String] ?=> Int = {

--- a/yaes-core/src/test/scala/in/rcard/yaes/RaiseSpec.scala
+++ b/yaes-core/src/test/scala/in/rcard/yaes/RaiseSpec.scala
@@ -713,6 +713,30 @@ class RaiseSpec extends AsyncFlatSpec with Matchers {
     result.left.map(_.toSet) should be(Left(Set("error2", "error4")))
   }
 
+  it should "catch subclasses of E" in {
+    val result = Raise.either[RuntimeException, Int] {
+      Raise.catching[RuntimeException, Int](throw new ArithmeticException("/ by zero"))
+    }
+    result shouldBe a[Left[?, ?]]
+    result.left.get shouldBe a[ArithmeticException]
+  }
+
+  it should "catch exact class E" in {
+    val result = Raise.either[ArithmeticException, Int] {
+      Raise.catching[ArithmeticException, Int](throw new ArithmeticException("/ by zero"))
+    }
+    result shouldBe a[Left[?, ?]]
+    result.left.get shouldBe a[ArithmeticException]
+  }
+
+  it should "not catch sibling exceptions unrelated to E" in {
+    assertThrows[ArithmeticException] {
+      Raise.either[IllegalArgumentException, Int] {
+        Raise.catching[IllegalArgumentException, Int](throw new ArithmeticException("/ by zero"))
+      }
+    }
+  }
+
   private def int(value: Int): Raise[String] ?=> Int = {
     if value >= 2 then Raise.raise(value.toString)
     else value

--- a/yaes-core/src/test/scala/in/rcard/yaes/RaiseSpec.scala
+++ b/yaes-core/src/test/scala/in/rcard/yaes/RaiseSpec.scala
@@ -717,16 +717,18 @@ class RaiseSpec extends AsyncFlatSpec with Matchers {
     val result = Raise.either[RuntimeException, Int] {
       Raise.catching[RuntimeException, Int](throw new ArithmeticException("/ by zero"))
     }
-    result shouldBe a[Left[?, ?]]
-    result.left.get shouldBe a[ArithmeticException]
+    result match
+      case Left(ex) => ex shouldBe a[ArithmeticException]
+      case Right(_) => fail("expected Left")
   }
 
   it should "catch exact class E" in {
     val result = Raise.either[ArithmeticException, Int] {
       Raise.catching[ArithmeticException, Int](throw new ArithmeticException("/ by zero"))
     }
-    result shouldBe a[Left[?, ?]]
-    result.left.get shouldBe a[ArithmeticException]
+    result match
+      case Left(ex) => ex shouldBe a[ArithmeticException]
+      case Right(_) => fail("expected Left")
   }
 
   it should "not catch sibling exceptions unrelated to E" in {


### PR DESCRIPTION
## Summary

- Fixes #253: `Raise.catching[E]` used `nfex.getClass == E.runtimeClass` (exact class match), causing it to miss exceptions of subclasses of `E`.
- Changed the check to `E.runtimeClass.isInstance(nfex)` so polymorphic catching works correctly (e.g. `catching[RuntimeException]` now catches `ArithmeticException`).

## Changes

- **`yaes-core/src/main/scala/in/rcard/yaes/Raise.scala`**: One-word fix — `==` comparison replaced with `.isInstance(nfex)`.
- **`yaes-core/src/test/scala/in/rcard/yaes/RaiseSpec.scala`**: Two regression tests added under the existing `"Raise.catching"` suite:
  1. Catches subclass of `E` (`ArithmeticException` when `E = RuntimeException`)
  2. Does not catch sibling exceptions unrelated to `E`

## Test plan

- [x] `sbt -batch --no-colors "yaes-core/testOnly in.rcard.yaes.RaiseSpec"` — 66 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)