### PR TITLE
feat: Add / path-segment operator to Uri

### DIFF
--- a/website/src/content/docs/http/client.md
+++ b/website/src/content/docs/http/client.md
@@ -489,7 +489,7 @@ Raise.run[Uri.InvalidUri] {
 }
 ```
 
-Any type with a `PathParamStringifier` instance is accepted — the same built-in instances (`String`, `Int`, `Long`, `Boolean`, `Double`, `UUID`) and custom `given` instances all work. A trailing slash on the base URI is normalised before appending, so `base / "x"` and `base/ / "x"` produce identical results.
+Any type with a `PathParamStringifier` instance is accepted — the same built-in instances (`String`, `Int`, `Long`, `Boolean`, `Double`, `UUID`) and custom `given` instances all work. A trailing slash on the base URI is normalised before appending, so `Uri("https://api.example.com/users") / "x"` and `Uri("https://api.example.com/users/") / "x"` produce identical results.
 
 ---
 

--- a/website/src/content/docs/http/client.md
+++ b/website/src/content/docs/http/client.md
@@ -449,7 +449,7 @@ result match
 |--------|-------------|-------------|
 | `value` | `String` | The URI as a string |
 | `host` | `Option[String]` | The host component |
-| `port` | `Int` | The port (defaults to 80 if unspecified) |
+| `port` | `Int` | The port (defaults to 443 for `https` and 80 otherwise, if unspecified) |
 | `toJavaURI` | `java.net.URI` | The underlying Java URI |
 | `/ (segment)` | `Uri` | Append a URL-encoded path segment |
 

--- a/website/src/content/docs/http/client.md
+++ b/website/src/content/docs/http/client.md
@@ -15,6 +15,7 @@ An effect-based HTTP client built on YAES effects and Java's `java.net.http.Http
 - **Fluent builder API** - Immutable request construction with `header`, `queryParam`, and `timeout` extension methods
 - **Body codecs** - Request body encoding via `BodyEncoder` and response body decoding via `BodyDecoder`
 - **URI validation** - Opaque `Uri` type with construction-time validation via the `Raise` effect
+- **Path segment operator** - `uri / segment` to append URL-encoded segments dynamically, preserving query strings and fragments
 - **Path parameter interpolation** - `uri"..."` string interpolator for ergonomic, type-safe path param encoding via `PathParamStringifier`
 
 **Requirements:**
@@ -450,6 +451,45 @@ result match
 | `host` | `Option[String]` | The host component |
 | `port` | `Int` | The port (defaults to 80 if unspecified) |
 | `toJavaURI` | `java.net.URI` | The underlying Java URI |
+| `/ (segment)` | `Uri` | Append a URL-encoded path segment |
+
+### Path Segment Operator (`/`)
+
+Use `uri / segment` to append a single path segment to an existing `Uri`. The segment is URL-encoded via the same `PathParamStringifier` typeclass used by the `uri"..."` interpolator. Query strings and fragments are preserved.
+
+```scala
+import in.rcard.yaes.*
+import in.rcard.yaes.http.client.*
+
+Raise.run[Uri.InvalidUri] {
+  val base   = Uri("https://api.example.com/users")
+  val userId = 42
+
+  val uri = base / userId
+  // => https://api.example.com/users/42
+}
+```
+
+Operators chain naturally:
+
+```scala
+Raise.run[Uri.InvalidUri] {
+  val uri = Uri("https://api.example.com") / "users" / 42 / "orders"
+  // => https://api.example.com/users/42/orders
+}
+```
+
+Query strings and fragments survive the append:
+
+```scala
+Raise.run[Uri.InvalidUri] {
+  val base = Uri("https://api.example.com/users?active=true")
+  val uri  = base / 42
+  // => https://api.example.com/users/42?active=true
+}
+```
+
+Any type with a `PathParamStringifier` instance is accepted — the same built-in instances (`String`, `Int`, `Long`, `Boolean`, `Double`, `UUID`) and custom `given` instances all work. A trailing slash on the base URI is normalised before appending, so `base / "x"` and `base/ / "x"` produce identical results.
 
 ---
 

--- a/yaes-http/client/README.md
+++ b/yaes-http/client/README.md
@@ -29,6 +29,7 @@ libraryDependencies += "in.rcard.yaes" %% "yaes-http-client" % "0.19.0"
 - **Fluent Builder API**: Immutable request building with `header`, `queryParam`, and `timeout` extension methods
 - **Body Codecs**: Request body encoding via `BodyEncoder` and response body decoding via `BodyDecoder`
 - **URI Validation**: Opaque `Uri` type with compile-time-safe construction via the `Raise` effect
+- **Path Segment Operator**: `uri / segment` to append URL-encoded segments dynamically, preserving query strings and fragments
 - **Path Parameter Interpolation**: `uri"..."` string interpolator for ergonomic, type-safe path param encoding via `PathParamStringifier`
 - **Configurable**: Connect timeout, redirect policy, and HTTP version selection
 
@@ -378,6 +379,41 @@ result match
   case Right(uri) =>
     println(s"Host: ${uri.host}, Port: ${uri.port}")
 ```
+
+### Path Segment Operator (`/`)
+
+Use `uri / segment` to append a single path segment to an existing `Uri`. The segment is URL-encoded via the same `PathParamStringifier` typeclass used by the `uri"..."` interpolator. Query strings and fragments are preserved.
+
+```scala
+Raise.run[Uri.InvalidUri] {
+  val base   = Uri("https://api.example.com/users")
+  val userId = 42
+
+  val uri = base / userId
+  // => https://api.example.com/users/42
+}
+```
+
+Operators chain naturally:
+
+```scala
+Raise.run[Uri.InvalidUri] {
+  val uri = Uri("https://api.example.com") / "users" / 42 / "orders"
+  // => https://api.example.com/users/42/orders
+}
+```
+
+Query strings and fragments survive the append:
+
+```scala
+Raise.run[Uri.InvalidUri] {
+  val base = Uri("https://api.example.com/users?active=true")
+  val uri  = base / 42
+  // => https://api.example.com/users/42?active=true
+}
+```
+
+Any type with a `PathParamStringifier` instance is accepted. A trailing slash on the base URI is normalised before appending.
 
 ## Body Codecs
 

--- a/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/Uri.scala
+++ b/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/Uri.scala
@@ -60,6 +60,24 @@ object Uri:
       else if Option(uri.getScheme).exists(_.equalsIgnoreCase("https")) then 443
       else 80
 
+    /** Appends a URL-encoded path segment to this URI.
+      *
+      * Trailing slashes on the base URI are normalised before appending, so
+      * chained calls always produce a clean path.
+      *
+      * Example:
+      * {{{
+      * val base = uri"https://api.example.com/users"
+      * val id   = 42L
+      * val u    = base / id   // https://api.example.com/users/42
+      * }}}
+      *
+      * @param segment the path segment to append, URL-encoded via [[UriParam]]
+      * @return a new [[Uri]] with the segment appended
+      */
+    def /(segment: UriParam): Uri =
+      Uri.fromTrustedString(s"${uri.value.stripSuffix("/")}/${segment.encoded}")
+
     /** Appends query parameters to the URI, URL-encoding keys and values.
       *
       * If the URI already contains a query string, parameters are appended with `&`.

--- a/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/Uri.scala
+++ b/yaes-http/client/src/main/scala/in/rcard/yaes/http/client/Uri.scala
@@ -62,8 +62,9 @@ object Uri:
 
     /** Appends a URL-encoded path segment to this URI.
       *
-      * Trailing slashes on the base URI are normalised before appending, so
-      * chained calls always produce a clean path.
+      * Trailing slashes on the base URI path are normalised before appending, so
+      * chained calls always produce a clean path. Existing query strings and
+      * fragments are preserved.
       *
       * Example:
       * {{{
@@ -72,11 +73,16 @@ object Uri:
       * val u    = base / id   // https://api.example.com/users/42
       * }}}
       *
-      * @param segment the path segment to append, URL-encoded via [[UriParam]]
+      * @param segment the path segment to append; any value with a [[PathParamStringifier]] is accepted via implicit conversion
       * @return a new [[Uri]] with the segment appended
       */
     def /(segment: UriParam): Uri =
-      Uri.fromTrustedString(s"${uri.value.stripSuffix("/")}/${segment.encoded}")
+      val raw     = uri.toASCIIString
+      val qIdx    = raw.indexOf('?')
+      val fIdx    = raw.indexOf('#')
+      val pathEnd = (List(qIdx, fIdx).filter(_ >= 0) :+ raw.length).min
+      val (pathPart, rest) = raw.splitAt(pathEnd)
+      Uri.fromTrustedString(s"${pathPart.stripSuffix("/")}/${segment.encoded}$rest")
 
     /** Appends query parameters to the URI, URL-encoding keys and values.
       *

--- a/yaes-http/client/src/test/scala/in/rcard/yaes/http/client/UriPathOpsSpec.scala
+++ b/yaes-http/client/src/test/scala/in/rcard/yaes/http/client/UriPathOpsSpec.scala
@@ -44,6 +44,18 @@ class UriPathOpsSpec extends AnyFlatSpec with Matchers:
     result.value shouldBe "https://api.example.com/search/hello%20world"
   }
 
+  it should "preserve an existing query string when appending a segment" in {
+    val base   = makeUri("https://api.example.com/users?page=1")
+    val result = base / "profile"
+    result.value shouldBe "https://api.example.com/users/profile?page=1"
+  }
+
+  it should "preserve an existing fragment when appending a segment" in {
+    val base   = makeUri("https://api.example.com/docs#section")
+    val result = base / "intro"
+    result.value shouldBe "https://api.example.com/docs/intro#section"
+  }
+
   it should "work with a custom PathParamStringifier" in {
     case class ProductId(value: Int)
     given PathParamStringifier[ProductId] with {

--- a/yaes-http/client/src/test/scala/in/rcard/yaes/http/client/UriPathOpsSpec.scala
+++ b/yaes-http/client/src/test/scala/in/rcard/yaes/http/client/UriPathOpsSpec.scala
@@ -1,0 +1,56 @@
+package in.rcard.yaes.http.client
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import in.rcard.yaes.*
+import in.rcard.yaes.http.client.Uri.InvalidUri
+
+class UriPathOpsSpec extends AnyFlatSpec with Matchers:
+
+  private def makeUri(raw: String): Uri =
+    Raise.either[InvalidUri, Uri] { Uri(raw) } match
+      case Left(e)  => fail(s"Invalid URI: ${e.reason}")
+      case Right(u) => u
+
+  "/ operator" should "append a plain string segment" in {
+    val base   = makeUri("https://api.example.com/v1")
+    val result = base / "users"
+    result.value shouldBe "https://api.example.com/v1/users"
+  }
+
+  it should "append a numeric Long segment via implicit conversion" in {
+    val base   = makeUri("https://api.example.com/users")
+    val id     = 42L
+    val result = base / id
+    result.value shouldBe "https://api.example.com/users/42"
+  }
+
+  it should "normalise a trailing slash on the base URI" in {
+    val base   = makeUri("https://api.example.com/users/")
+    val result = base / "profile"
+    result.value shouldBe "https://api.example.com/users/profile"
+  }
+
+  it should "support chained / calls" in {
+    val base   = makeUri("https://api.example.com")
+    val id     = 7L
+    val result = base / "users" / id
+    result.value shouldBe "https://api.example.com/users/7"
+  }
+
+  it should "URL-encode segments with special characters" in {
+    val base   = makeUri("https://api.example.com/search")
+    val result = base / "hello world"
+    result.value shouldBe "https://api.example.com/search/hello%20world"
+  }
+
+  it should "work with a custom PathParamStringifier" in {
+    case class ProductId(value: Int)
+    given PathParamStringifier[ProductId] with {
+      def encode(v: ProductId): String = s"prod-${v.value}"
+    }
+    val base   = makeUri("https://api.example.com/catalog")
+    val pid    = ProductId(99)
+    val result = base / pid
+    result.value shouldBe "https://api.example.com/catalog/prod-99"
+  }


### PR DESCRIPTION
## Summary

- Adds a `/` infix extension method to `Uri` that appends a URL-encoded path segment
- Trailing slashes on the base URI are normalised before appending, so chained calls produce clean paths
- The operator accepts any `UriParam`-convertible value (any type with a `PathParamStringifier` given)

## Test plan

- [ ] Appends a plain string segment
- [ ] Appends a numeric (`Long`) segment via implicit conversion
- [ ] Normalises trailing slash on base URI (no double slash)
- [ ] Chains multiple `/` calls: `base / "users" / id`
- [ ] URL-encodes segments with special characters (spaces → `%20`)
- [ ] Works with a custom `PathParamStringifier`

All 8 tests pass in `UriPathOpsSpec`.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)