### PR TITLE
Set required Java to 25 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The library is only available for Scala 3 and is currently in an experimental st
 
 ### Requirements
 
-- **Java 24 or higher** is required to run λÆS due to its use of modern Java features like Virtual Threads and Structured Concurrency.
+- **Exactly Java 25** is required to run λÆS due to its use of modern Java features like Virtual Threads and preview ones like Structured Concurrency.
 
 ## Usage
 


### PR DESCRIPTION
With Java 24 I have

```
Caused by: java.lang.NoClassDefFoundError: java/util/concurrent/StructuredTaskScope$FailedException
        at in.rcard.yaes.http.server.YaesServer$.$anonfun$1$$anonfun$1$$anonfun$1(YaesServer.scala:225)
        at in.rcard.yaes.Resource$package$Resource$$anon$1.install(Resource.scala:252)
        at in.rcard.yaes.http.server.YaesServer$.$anonfun$1$$anonfun$1(YaesServer.scala:264)
```

and with 26

```
Caused by: java.lang.NoSuchMethodError: 'java.util.concurrent.StructuredTaskScope java.util.concurrent.StructuredTaskScope.open(java.util.concurrent.StructuredTaskScope$Joiner, java.util.function.Function)'
        at in.rcard.yaes.Async$package$Async$.withGracefulShutdown(Async.scala:526)
        at in.rcard.yaes.http.server.YaesServer$.$anonfun$1$$anonfun$1$$anonfun$1(YaesServer.scala:263)
        at in.rcard.yaes.Resource$package$Resource$$anon$1.install(Resource.scala:252)
        at in.rcard.yaes.http.server.YaesServer$.$anonfun$1$$anonfun$1(YaesServer.scala:264)
```