### PR TITLE
fix: Restore the enclosing scope when a nested Async.run returns

### DIFF
--- a/yaes-core/src/main/scala/io/yaes/Async.scala
+++ b/yaes-core/src/main/scala/io/yaes/Async.scala
@@ -519,6 +519,9 @@ object Async {
     * }
     * }}}
     *
+    * It can also be nested inside an existing scope (e.g. an [[unsupervised]] block); the enclosing
+    * scope is saved and restored so it is left untouched.
+    *
     * @param block
     *   the async computation to run
     * @return
@@ -532,6 +535,7 @@ object Async {
     )
     // In JDK 25, fork() can only be called by the scope owner. Run program directly on
     // the calling thread so it is the owner and can fork child fibers on loomScope.
+    val prev = JvmAsync.scope.get()
     JvmAsync.scope.set(loomScope.asInstanceOf[StructuredTaskScope[Any, Any]])
     try {
       val result = block(using async)
@@ -545,7 +549,9 @@ object Async {
         Thread.interrupted()
         throw t
     } finally {
-      JvmAsync.scope.remove()
+      // Restore the previous scope (if any), so that a nested run leaves an enclosing scope intact.
+      if (prev != null) JvmAsync.scope.set(prev)
+      else JvmAsync.scope.remove()
       loomScope.close()
     }
   }

--- a/yaes-core/src/test/scala/io/yaes/AsyncNestedRunSpec.scala
+++ b/yaes-core/src/test/scala/io/yaes/AsyncNestedRunSpec.scala
@@ -1,0 +1,71 @@
+package io.yaes
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+
+import io.yaes.Async.*
+
+class AsyncNestedRunSpec extends AnyFlatSpec with Matchers {
+
+  "A nested Async.run" should "restore the enclosing unsupervised scope when it returns" in {
+    val queue = new ConcurrentLinkedQueue[String]()
+
+    val result = Async.unsupervised {
+      val nested = Async.run {
+        queue.add("nested")
+        1
+      }
+      // Forking here fails with a NullPointerException if the nested run wiped the enclosing scope.
+      val fiber = Async.fork {
+        queue.add("outer-fiber")
+      }
+      fiber.join()
+      nested + 1
+    }
+
+    result shouldBe 2
+    queue.toArray should contain theSameElementsInOrderAs List("nested", "outer-fiber")
+  }
+
+  it should "restore the enclosing unsupervised scope when it throws" in {
+    val counter = new AtomicInteger(0)
+
+    val result = Async.unsupervised {
+      try {
+        Async.run {
+          throw new RuntimeException("nested boom")
+        }
+      } catch {
+        case _: RuntimeException => ()
+      }
+      // The enclosing scope must survive the failure of the nested run.
+      val fiber = Async.fork {
+        counter.incrementAndGet()
+      }
+      fiber.join()
+      counter.get()
+    }
+
+    result shouldBe 1
+  }
+
+  it should "restore the enclosing run scope when it returns" in {
+    val counter = new AtomicInteger(0)
+
+    val result = Async.run {
+      val nested = Async.run {
+        counter.incrementAndGet()
+      }
+      val fiber = Async.fork {
+        counter.incrementAndGet()
+      }
+      fiber.join()
+      nested + counter.get()
+    }
+
+    result shouldBe 3
+  }
+}


### PR DESCRIPTION
## The defect

`Async.run` sets the `JvmAsync.scope` ThreadLocal without capturing the previous binding, and its `finally` block calls an unconditional `JvmAsync.scope.remove()`:

```scala
JvmAsync.scope.set(loomScope.asInstanceOf[StructuredTaskScope[Any, Any]])
try { ... } finally {
  JvmAsync.scope.remove()
  loomScope.close()
}
```

`Async.unsupervised` already does this correctly: it captures `val prev = JvmAsync.scope.get()` before the `set` and restores `if (prev != null) JvmAsync.scope.set(prev) else JvmAsync.scope.remove()`.

Consequence: an `Async.run` nested inside an enclosing scope wipes the outer scope binding on exit. `JvmAsync.fork` does `JvmAsync.scope.get().fork(...)`, so the next `Async.fork` in the outer block fails with:

```
java.lang.NullPointerException: Cannot invoke
  "java.util.concurrent.StructuredTaskScope.fork(java.util.concurrent.Callable)"
  because the return value of "java.lang.ThreadLocal.get()" is null
```

This hits a documented supported nesting: the `Async.unsupervised` Scaladoc states that it can be nested inside a `run` block and that scopes are saved and restored. The reverse nesting (`run` inside `unsupervised`) was broken. `run` inside `run` was broken for the same reason.

## The fix

Make `run` symmetric with `unsupervised`: capture `prev` before the `set`, restore it in the `finally`, falling back to `remove()` when there was no enclosing scope. `loomScope.close()` and the existing `FailedException` / `Throwable` handling are untouched. The `run` Scaladoc now documents the nesting guarantee, mirroring the wording already used on `unsupervised`.

## The regression test

New spec `yaes-core/src/test/scala/io/yaes/AsyncNestedRunSpec.scala` (a new file rather than an edit to `AsyncUnsupervisedSpec.scala`, to avoid conflicting with concurrent work on that file). Three cases, each forking in the outer scope *after* the nested `Async.run` has returned or thrown, which is the exact path that NPEs:

1. nested `run` inside `unsupervised`, normal return
2. nested `run` inside `unsupervised`, throwing (the `finally` restore path)
3. nested `run` inside `run`

**Before the fix** (`Async.scala` unchanged, new spec only):

```
[info] A nested Async.run
[info] - should restore the enclosing unsupervised scope when it returns *** FAILED ***
[info]   java.lang.NullPointerException: Cannot invoke "java.util.concurrent.StructuredTaskScope.fork(java.util.concurrent.Callable)" because the return value of "java.lang.ThreadLocal.get()" is null
[info] - should restore the enclosing unsupervised scope when it throws *** FAILED ***
[info]   java.lang.NullPointerException: Cannot invoke "java.util.concurrent.StructuredTaskScope.fork(java.util.concurrent.Callable)" because the return value of "java.lang.ThreadLocal.get()" is null
[info] - should restore the enclosing run scope when it returns *** FAILED ***
[info]   java.lang.NullPointerException: Cannot invoke "java.util.concurrent.StructuredTaskScope.fork(java.util.concurrent.Callable)" because the return value of "java.lang.ThreadLocal.get()" is null
[info] Tests: succeeded 0, failed 3, canceled 0, ignored 0, pending 0
[info] *** 3 TESTS FAILED ***
```

**After the fix**, full `yaes-core` suite:

```
[info] AsyncNestedRunSpec:
[info] A nested Async.run
[info] - should restore the enclosing unsupervised scope when it returns (3 milliseconds)
[info] - should restore the enclosing unsupervised scope when it throws (3 milliseconds)
[info] - should restore the enclosing run scope when it returns (2 milliseconds)
[info] Run completed in 30 seconds, 75 milliseconds.
[info] Total number of tests run: 329
[info] Suites: completed 23, aborted 0
[info] Tests: succeeded 329, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 31 s
```

`AsyncSpec` and `AsyncUnsupervisedSpec` are included in that run and both pass.

## Note

PR #318 depends on this landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
