### PR TITLE
feat(309): add Async.never blocking primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Using the `Async.fork` DSL is quite low-level. The library provides a set of str
 - `Async.raceSuccess`: Like `Async.race`, but ignores failures unless both branches fail — it keeps waiting on the surviving branch instead of letting a fast failure beat a slow success. Only fails if *both* branches fail, surfacing the last observed failure.
 - `Async.racePair`: Runs two asynchronous computations in parallel and returns the result of the first computation that finishes along with the fiber that is still running.
 - `Async.parTraverse`: Executes a function over all elements of a collection in parallel, returning results in input order.
+- `Async.never`: A computation that never completes on its own; useful as a branch of `Async.race`, `Async.raceSuccess`, or `Async.timeout` that must be cancelled or timed out rather than complete by itself. It must always be forked (directly or through a combinator like `race`) and that fork must be cancelled, raced away, or wrapped in a timeout, otherwise the enclosing `Async.run` blocks forever.
 
 #### Parallel Traversal
 

--- a/website/src/content/docs/learn/5-concurrency.md
+++ b/website/src/content/docs/learn/5-concurrency.md
@@ -176,6 +176,26 @@ Unlike `race`, `raceSuccess` keeps waiting on the surviving branch when one of t
 val (winner, remaining) = Async.racePair(computation1, computation2)
 ```
 
+**Never Completing**: a computation that blocks forever on its own:
+
+```scala
+import io.yaes.Async.*
+import scala.concurrent.duration.*
+
+val result: Int = Async.run {
+  Async.race(
+    Async.never, // never completes on its own
+    {
+      Async.delay(1.second)
+      42
+    }
+  )
+}
+// result == 42; the never branch is cancelled once the other one wins
+```
+
+`Async.never` parks the fiber efficiently, without busy-waiting, until it is cancelled. It is useful for a computation that must run until cancelled, or for a branch of `race`, `raceSuccess`, or `timeout` that should never complete on its own. It must always be forked, directly with `fork`/`attemptFork` or indirectly through a combinator such as `race` that forks its branches for you, and that fork must itself be cancelled, raced away, or wrapped in `timeout`. A bare `Async.run { Async.never }` with no fork in between hangs forever, and so does a forked `never` left un-cancelled and un-raced directly inside `run`, since `run` waits for every forked fiber to finish, joined or not. `Async.unsupervised` does not have that problem: it cancels any fiber still running as soon as its block returns. `par` and `parTraverse` wait for every branch to finish before returning, so pairing either of them with `never` deadlocks unconditionally.
+
 ### Key Features
 
 - **Structured Concurrency**: All fibers are properly managed and cleaned up

--- a/yaes-core/src/main/scala/io/yaes/Async.scala
+++ b/yaes-core/src/main/scala/io/yaes/Async.scala
@@ -360,6 +360,71 @@ object Async {
     async.delay(duration)
   }
 
+  /** Blocks the calling fiber indefinitely, never returning on its own.
+    *
+    * `never` parks the fiber efficiently (a blocking wait, not a busy loop) until the fiber is
+    * cancelled, either explicitly via [[Fiber.cancel]] or because the enclosing scope (e.g.
+    * [[run]]) is torn down. Cancellation reaches it exactly the same way it reaches any other
+    * blocking `Async` operation such as [[delay]]: cooperative interruption. Since the calling
+    * thread only ever leaves the park by being interrupted, no exception it raises escapes to user
+    * code as an untracked failure; it flows through the same handling [[fork]] already applies to
+    * an interrupted fiber.
+    *
+    * This is useful for a computation that must "run until cancelled", or for a branch of [[race]],
+    * [[par]], or [[timeout]] that should never complete on its own.
+    *
+    * Example:
+    * {{{
+    * val result = Async.run {
+    *   Async.race(
+    *     Async.never, // never completes on its own
+    *     {
+    *       Async.delay(1.second)
+    *       42
+    *     }
+    *   )
+    * }
+    * // result == 42; the `never` branch is cancelled once the other one wins
+    * }}}
+    *
+    * @param async
+    *   the async context; required for API consistency with every other `Async` operation, even
+    *   though parking forever has no backend-specific behavior for this implementation to delegate
+    *   to
+    * @tparam A
+    *   the type of value this method would produce, if it ever returned one
+    * @return
+    *   never returns; the calling fiber parks until it is cancelled
+    * @see
+    *   [[race]], [[timeout]] for typical use sites of a branch that never completes on its own
+    */
+  def never[A](using async: Async): A = parkForever()
+
+  /** Parks the calling thread forever on a [[CountDownLatch]] that is never counted down.
+    *
+    * `await()` on a latch stuck at one can only return by throwing `InterruptedException` once the
+    * thread is interrupted. That is the same signal `Thread.sleep` (used by [[JvmAsync.delay]])
+    * raises on interruption, so it flows through the identical cancellation path already handled by
+    * [[JvmAsync.forkImpl]], which turns it into the fiber's promise being cancelled. Unlike
+    * `LockSupport.park()`, `CountDownLatch.await()` cannot wake up spuriously, so no wrapping loop
+    * is needed here; a loop would only be needed to guard against a wakeup that isn't the real
+    * interruption, which this call cannot produce.
+    *
+    * The statement after `await()` is unreachable in practice: the latch is never counted down, so
+    * the only way execution continues past it is via the exception the JVM raises on interrupt.
+    * The `Nothing` return type documents that explicitly, rather than silently returning a bogus
+    * value typed as whatever the caller expected.
+    *
+    * @return
+    *   never returns normally
+    */
+  private def parkForever(): Nothing = {
+    new CountDownLatch(1).await()
+    throw new IllegalStateException(
+      "unreachable: an uncounted CountDownLatch.await() only returns via InterruptedException"
+    )
+  }
+
   /** Creates a new fiber with a specified name.
     *
     * This method is deliberately not an overload of [[fork]]: a block whose type conforms to

--- a/yaes-core/src/main/scala/io/yaes/Async.scala
+++ b/yaes-core/src/main/scala/io/yaes/Async.scala
@@ -167,6 +167,17 @@ class JvmAsync extends Async.Unsafe {
 
   override def attemptFork[A](name: String)(block: => A): Fiber[A] =
     JvmAsync.forkImpl(name, rethrowOnFailure = false)(block)
+
+  override def never[A](): Nothing = {
+    new CountDownLatch(1).await()
+    // Unreachable: the latch above is never counted down, so `await()` can only return by
+    // throwing InterruptedException once this thread is interrupted. Throwing that same
+    // exception here (rather than e.g. IllegalStateException) keeps this a call site the
+    // JvmAsync.forkImpl's `case _: InterruptedException` arm still recognizes, so even this
+    // unreachable path would cancel the fiber cleanly instead of poisoning the enclosing scope
+    // with what would otherwise look like a genuine failure.
+    throw new InterruptedException()
+  }
 }
 object JvmAsync {
 
@@ -363,15 +374,32 @@ object Async {
   /** Blocks the calling fiber indefinitely, never returning on its own.
     *
     * `never` parks the fiber efficiently (a blocking wait, not a busy loop) until the fiber is
-    * cancelled, either explicitly via [[Fiber.cancel]] or because the enclosing scope (e.g.
-    * [[run]]) is torn down. Cancellation reaches it exactly the same way it reaches any other
-    * blocking `Async` operation such as [[delay]]: cooperative interruption. Since the calling
-    * thread only ever leaves the park by being interrupted, no exception it raises escapes to user
-    * code as an untracked failure; it flows through the same handling [[fork]] already applies to
-    * an interrupted fiber.
+    * cancelled, either explicitly via [[Fiber.cancel]] or through the same interrupt-based
+    * cancellation that reaches any other blocking `Async` operation such as [[delay]], for example
+    * when [[unsupervised]] tears down a scope whose block already returned.
     *
-    * This is useful for a computation that must "run until cancelled", or for a branch of [[race]],
-    * [[par]], or [[timeout]] that should never complete on its own.
+    * @note
+    *   `never` must be forked (directly with [[fork]]/[[attemptFork]], or indirectly through a
+    *   combinator such as [[race]] that forks its branches for you), and that fork must itself be
+    *   cancelled, raced away, or wrapped in [[timeout]]. A bare `Async.run { Async.never }`, with no
+    *   fork in between, runs on the caller thread with nothing able to cancel it and hangs forever;
+    *   `Async.run` cannot help here because it only reaches its own teardown after the block
+    *   returns, which a `never` inside that block prevents. The same is true of a forked `never`
+    *   that is left un-cancelled and un-raced directly inside [[run]]: `run` waits for every forked
+    *   fiber to finish, joined or not, so it hangs just the same. [[unsupervised]] does not have
+    *   that failure mode: it cancels any fiber still running as soon as its block returns, so a
+    *   `never` forked inside it is torn down correctly with no explicit `cancel()` needed.
+    * @note
+    *   On the forked path, the interrupt that unparks `never` is handled by [[fork]]'s own
+    *   cancellation logic, so it never escapes to user code as an untracked exception. That
+    *   guarantee is specific to the forked path; see the note above for the unforked case, where no
+    *   such handling exists and the interrupt is left to propagate on its own.
+    *
+    * This is useful for a computation that must "run until cancelled", or for a branch of [[race]]
+    * or [[timeout]] that should never complete on its own. [[raceSuccess]] also works with `never`,
+    * but only helps when the other branch can actually succeed. [[par]] and [[parTraverse]], by
+    * contrast, wait for *every* branch to finish before returning, so pairing either of them with
+    * `never` deadlocks unconditionally, not just in the unlucky case.
     *
     * Example:
     * {{{
@@ -388,42 +416,17 @@ object Async {
     * }}}
     *
     * @param async
-    *   the async context; required for API consistency with every other `Async` operation, even
-    *   though parking forever has no backend-specific behavior for this implementation to delegate
-    *   to
+    *   the async context; delegates to [[Async.Unsafe.never]] for the actual parking
+    *   implementation, exactly like every other `Async` operation delegates to its backend
     * @tparam A
     *   the type of value this method would produce, if it ever returned one
     * @return
     *   never returns; the calling fiber parks until it is cancelled
     * @see
-    *   [[race]], [[timeout]] for typical use sites of a branch that never completes on its own
+    *   [[race]], [[timeout]], [[raceSuccess]] for typical use sites of a branch that never
+    *   completes on its own
     */
-  def never[A](using async: Async): A = parkForever()
-
-  /** Parks the calling thread forever on a [[CountDownLatch]] that is never counted down.
-    *
-    * `await()` on a latch stuck at one can only return by throwing `InterruptedException` once the
-    * thread is interrupted. That is the same signal `Thread.sleep` (used by [[JvmAsync.delay]])
-    * raises on interruption, so it flows through the identical cancellation path already handled by
-    * [[JvmAsync.forkImpl]], which turns it into the fiber's promise being cancelled. Unlike
-    * `LockSupport.park()`, `CountDownLatch.await()` cannot wake up spuriously, so no wrapping loop
-    * is needed here; a loop would only be needed to guard against a wakeup that isn't the real
-    * interruption, which this call cannot produce.
-    *
-    * The statement after `await()` is unreachable in practice: the latch is never counted down, so
-    * the only way execution continues past it is via the exception the JVM raises on interrupt.
-    * The `Nothing` return type documents that explicitly, rather than silently returning a bogus
-    * value typed as whatever the caller expected.
-    *
-    * @return
-    *   never returns normally
-    */
-  private def parkForever(): Nothing = {
-    new CountDownLatch(1).await()
-    throw new IllegalStateException(
-      "unreachable: an uncounted CountDownLatch.await() only returns via InterruptedException"
-    )
-  }
+  def never[A](using async: Async): A = async.never()
 
   /** Creates a new fiber with a specified name.
     *
@@ -1027,5 +1030,25 @@ object Async {
       *   a [[Fiber]] representing the forked computation
       */
     def attemptFork[A](name: String)(block: => A): Fiber[A] = fork(name)(block)
+
+    /** Parks the calling thread until it is cancelled, never returning a value on its own.
+      *
+      * This is the backend seam behind [[Async.never]]. The JVM backend ([[JvmAsync]]) parks on an
+      * uncounted [[java.util.concurrent.CountDownLatch]] that is never counted down: the only way
+      * `await()` on it returns is by throwing `InterruptedException` once the thread is
+      * interrupted, the same cancellation signal [[delay]] and [[fork]] already rely on.
+      *
+      * A backend whose cancellation mechanism is not interrupt based, i.e. one that does not
+      * ultimately call `Thread.interrupt()` to cancel a fiber, must override this method with a
+      * parking primitive that responds to whatever signal that backend uses instead. Inheriting the
+      * JVM behavior on such a backend would compile cleanly but produce an `Async.never` that can
+      * never actually be cancelled.
+      *
+      * @tparam A
+      *   the type of value this method would produce, if it ever returned one
+      * @return
+      *   never returns normally
+      */
+    def never[A](): Nothing
   }
 }

--- a/yaes-core/src/main/scala/io/yaes/Async.scala
+++ b/yaes-core/src/main/scala/io/yaes/Async.scala
@@ -168,7 +168,7 @@ class JvmAsync extends Async.Unsafe {
   override def attemptFork[A](name: String)(block: => A): Fiber[A] =
     JvmAsync.forkImpl(name, rethrowOnFailure = false)(block)
 
-  override def never[A](): Nothing = {
+  override def never(): Nothing = {
     new CountDownLatch(1).await()
     // Unreachable: the latch above is never counted down, so `await()` can only return by
     // throwing InterruptedException once this thread is interrupted. Throwing that same
@@ -1038,17 +1038,19 @@ object Async {
       * `await()` on it returns is by throwing `InterruptedException` once the thread is
       * interrupted, the same cancellation signal [[delay]] and [[fork]] already rely on.
       *
-      * A backend whose cancellation mechanism is not interrupt based, i.e. one that does not
-      * ultimately call `Thread.interrupt()` to cancel a fiber, must override this method with a
-      * parking primitive that responds to whatever signal that backend uses instead. Inheriting the
-      * JVM behavior on such a backend would compile cleanly but produce an `Async.never` that can
-      * never actually be cancelled.
+      * This method has no default implementation; every backend must supply its own. No default
+      * would be safe here: returning a value is impossible given the `Nothing` result type,
+      * throwing an untracked exception would violate this project's error handling philosophy, and
+      * looping to avoid both would burn CPU forever and defeat the purpose of parking.
       *
-      * @tparam A
-      *   the type of value this method would produce, if it ever returned one
+      * On an interrupt based backend, implement this by parking on any interruptible primitive, the
+      * same way [[JvmAsync]] parks on an uncounted `CountDownLatch`. On a backend whose cancellation
+      * mechanism is not interrupt based, i.e. one that does not ultimately call `Thread.interrupt()`
+      * to cancel a fiber, park on whatever signal that backend uses instead to cancel a fiber.
+      *
       * @return
       *   never returns normally
       */
-    def never[A](): Nothing
+    def never(): Nothing
   }
 }

--- a/yaes-core/src/test/scala/io/yaes/AsyncNeverSpec.scala
+++ b/yaes-core/src/test/scala/io/yaes/AsyncNeverSpec.scala
@@ -116,7 +116,9 @@ class AsyncNeverSpec extends AnyFlatSpec with Matchers with TimeLimits {
     } shouldBe 42
     val elapsedMillis = (java.lang.System.nanoTime() - start) / 1000000L
 
-    elapsedMillis should be < 5000L
+    // Tightened to match the sibling test above: this test has no internal delay at all, so it
+    // has less fixed overhead to absorb and can afford the same tight bound.
+    elapsedMillis should be < 800L
   }
 
   it should "not throw any exception when joining a fiber cancelled while parked in never" in failAfter(

--- a/yaes-core/src/test/scala/io/yaes/AsyncNeverSpec.scala
+++ b/yaes-core/src/test/scala/io/yaes/AsyncNeverSpec.scala
@@ -10,6 +10,7 @@ import org.scalatest.time.Span
 
 import scala.concurrent.duration.*
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
 
 class AsyncNeverSpec extends AnyFlatSpec with Matchers with TimeLimits {
@@ -49,18 +50,26 @@ class AsyncNeverSpec extends AnyFlatSpec with Matchers with TimeLimits {
   it should "park the fiber instead of busy-waiting, observable as a blocked thread state" in failAfter(
     unblockTimeLimit
   ) {
-    val threadRef = new AtomicReference[Thread]()
+    val threadRef  = new AtomicReference[Thread]()
+    val readyLatch = new CountDownLatch(1)
     Async.run {
       val fiber = Async.fork {
         threadRef.set(Thread.currentThread())
+        readyLatch.countDown()
         Async.never[Int]
       }
-      // Give the fiber time to reach the park.
-      Async.delay(300.millis)
+      // Wait for the fiber to have actually started (and recorded its thread) before sampling
+      // its state, instead of guessing with a fixed sleep: on a loaded CI runner the fiber may
+      // not have been scheduled yet, which would otherwise read `threadRef` as null.
+      readyLatch.await()
+      // A short settle after the handshake so the fiber has time to move from RUNNABLE (just
+      // past the countDown) into the park inside `never`.
+      Async.delay(100.millis)
       val state = threadRef.get().getState
-      // A busy-wait / spin loop would observe RUNNABLE here. A real park reports WAITING or
-      // TIMED_WAITING (CountDownLatch.await() is a Condition await internally).
-      (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) shouldBe true
+      // A busy-wait / spin loop would observe RUNNABLE here. A real park on an uncounted
+      // CountDownLatch.await() (AQS `acquireSharedInterruptibly` plus `LockSupport.park`, not a
+      // `Condition` await) always reports WAITING, never TIMED_WAITING.
+      state shouldBe Thread.State.WAITING
       fiber.cancel()
       fiber.join()
     }
@@ -80,8 +89,10 @@ class AsyncNeverSpec extends AnyFlatSpec with Matchers with TimeLimits {
     }
     val elapsedMillis = (java.lang.System.nanoTime() - start) / 1000000L
 
-    // Cancellation should be near-instant; well under the generous failAfter ceiling.
-    elapsedMillis should be < 5000L
+    // Cancellation should be near-instant on top of the 200ms internal delay. Tight enough that
+    // a regression where cancellation itself took seconds (rather than being near-instant) would
+    // fail this test, unlike the previous 5000L bound which had roughly 25x slack.
+    elapsedMillis should be < 800L
   }
 
   it should "stop promptly when an unsupervised scope exits, without an explicit cancel()" in failAfter(
@@ -160,6 +171,36 @@ class AsyncNeverSpec extends AnyFlatSpec with Matchers with TimeLimits {
   it should "lose a race regardless of argument order" in failAfter(unblockTimeLimit) {
     val actualResult: Int = Async.run {
       Async.race(
+        {
+          Async.delay(200.millis)
+          42
+        },
+        Async.never[Int]
+      )
+    }
+
+    actualResult shouldBe 42
+  }
+
+  it should "lose a raceSuccess against a fast computation, which is cancelled once the fast one wins" in failAfter(
+    unblockTimeLimit
+  ) {
+    val actualResult: Int = Async.run {
+      Async.raceSuccess(
+        Async.never[Int],
+        {
+          Async.delay(200.millis)
+          42
+        }
+      )
+    }
+
+    actualResult shouldBe 42
+  }
+
+  it should "lose a raceSuccess regardless of argument order" in failAfter(unblockTimeLimit) {
+    val actualResult: Int = Async.run {
+      Async.raceSuccess(
         {
           Async.delay(200.millis)
           42

--- a/yaes-core/src/test/scala/io/yaes/AsyncNeverSpec.scala
+++ b/yaes-core/src/test/scala/io/yaes/AsyncNeverSpec.scala
@@ -34,10 +34,16 @@ class AsyncNeverSpec extends AnyFlatSpec with Matchers with TimeLimits {
     val actualQueue = new ConcurrentLinkedQueue[String]()
     Async.run {
       val fiber = Async.fork {
-        Async.never[Int]
+        val neverReturned: Int = Async.never[Int]
+        // Statically unreachable, but only as long as `never` honours its contract: a regression
+        // making it return on its own would run this line and add a second element to the queue,
+        // which is what lets the assertion below tell a still-parked fiber apart from one that
+        // already finished. Without it the test would pass even if `never` returned immediately.
+        actualQueue.add("never-returned")
+        neverReturned
       }
-      // Give the fiber ample time to reach the park; if `never` returned on its own, this
-      // callback would have already fired.
+      // Give the fiber ample time to reach the park (and, on a regression, to record its
+      // unexpected return) before we sample the queue.
       Async.delay(300.millis)
       actualQueue.add("still-running")
       fiber.cancel()

--- a/yaes-core/src/test/scala/io/yaes/AsyncNeverSpec.scala
+++ b/yaes-core/src/test/scala/io/yaes/AsyncNeverSpec.scala
@@ -1,0 +1,203 @@
+package io.yaes
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.concurrent.TimeLimits
+import org.scalatest.concurrent.Signaler
+import org.scalatest.concurrent.ThreadSignaler
+import org.scalatest.time.Seconds
+import org.scalatest.time.Span
+
+import scala.concurrent.duration.*
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicReference
+
+class AsyncNeverSpec extends AnyFlatSpec with Matchers with TimeLimits {
+
+  /** Interrupts the test thread when a `failAfter` limit expires.
+    *
+    * `Async.never` is designed to block forever. A regression (e.g. the park getting swallowed, or
+    * cancellation not reaching it) would hang `Async.run`'s `join()` forever instead of failing the
+    * test. Interrupting the test thread unwinds that `join()`, whose `close()` then cancels any
+    * still-parked fiber, turning a regression into a clean test failure instead of an unbounded
+    * hang.
+    */
+  private given Signaler = ThreadSignaler
+
+  /** Upper bound for every test in this spec. Generous enough to absorb CI jitter. */
+  private val unblockTimeLimit: Span = Span(30, Seconds)
+
+  "Async.never" should "not return on its own, keeping the fiber alive until cancelled" in failAfter(
+    unblockTimeLimit
+  ) {
+    val actualQueue = new ConcurrentLinkedQueue[String]()
+    Async.run {
+      val fiber = Async.fork {
+        Async.never[Int]
+      }
+      // Give the fiber ample time to reach the park; if `never` returned on its own, this
+      // callback would have already fired.
+      Async.delay(300.millis)
+      actualQueue.add("still-running")
+      fiber.cancel()
+      fiber.join()
+    }
+
+    actualQueue.toArray should contain theSameElementsInOrderAs List("still-running")
+  }
+
+  it should "park the fiber instead of busy-waiting, observable as a blocked thread state" in failAfter(
+    unblockTimeLimit
+  ) {
+    val threadRef = new AtomicReference[Thread]()
+    Async.run {
+      val fiber = Async.fork {
+        threadRef.set(Thread.currentThread())
+        Async.never[Int]
+      }
+      // Give the fiber time to reach the park.
+      Async.delay(300.millis)
+      val state = threadRef.get().getState
+      // A busy-wait / spin loop would observe RUNNABLE here. A real park reports WAITING or
+      // TIMED_WAITING (CountDownLatch.await() is a Condition await internally).
+      (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) shouldBe true
+      fiber.cancel()
+      fiber.join()
+    }
+  }
+
+  it should "stop promptly through the standard interruption path when the fiber is cancelled" in failAfter(
+    unblockTimeLimit
+  ) {
+    val start = java.lang.System.nanoTime()
+    Async.run {
+      val fiber = Async.fork {
+        Async.never[Int]
+      }
+      Async.delay(200.millis)
+      fiber.cancel()
+      fiber.join()
+    }
+    val elapsedMillis = (java.lang.System.nanoTime() - start) / 1000000L
+
+    // Cancellation should be near-instant; well under the generous failAfter ceiling.
+    elapsedMillis should be < 5000L
+  }
+
+  it should "stop promptly when an unsupervised scope exits, without an explicit cancel()" in failAfter(
+    unblockTimeLimit
+  ) {
+    // `Async.run` waits for every forked fiber via structured-concurrency join semantics, so a
+    // `never` fiber left un-cancelled there is expected to block `run` forever (that's the
+    // documented behavior of a supervised scope, not something `never` should defeat). An
+    // `unsupervised` scope, by contrast, is documented to cancel any fiber still running as soon
+    // as its block returns, without waiting on it first; that is the scope-exit cancellation path
+    // this test exercises.
+    val start = java.lang.System.nanoTime()
+    Async.run {
+      Async.unsupervised {
+        Async.fork {
+          Async.never[Int]
+        }
+        // Never joined or cancelled explicitly; unsupervised scope teardown must cancel it.
+        42
+      }
+    } shouldBe 42
+    val elapsedMillis = (java.lang.System.nanoTime() - start) / 1000000L
+
+    elapsedMillis should be < 5000L
+  }
+
+  it should "not throw any exception when joining a fiber cancelled while parked in never" in failAfter(
+    unblockTimeLimit
+  ) {
+    val actualResult = Async.run {
+      val fiber = Async.fork {
+        Async.never[Int]
+      }
+      Async.delay(200.millis)
+      fiber.cancel()
+      fiber.join()
+      42
+    }
+
+    actualResult shouldBe 42
+  }
+
+  it should "raise Cancelled (not an untracked exception) when asking for the value of a fiber cancelled while parked in never" in failAfter(
+    unblockTimeLimit
+  ) {
+    val actualResult: Int | Async.Cancelled = Raise.run {
+      Async.run {
+        val fiber = Async.fork {
+          Async.never[Int]
+        }
+        Async.delay(200.millis)
+        fiber.cancel()
+        fiber.value
+      }
+    }
+
+    actualResult shouldBe Async.Cancelled
+  }
+
+  it should "lose a race against a fast computation, which is cancelled once the fast one wins" in failAfter(
+    unblockTimeLimit
+  ) {
+    val actualResult: Int = Async.run {
+      Async.race(
+        Async.never[Int],
+        {
+          Async.delay(200.millis)
+          42
+        }
+      )
+    }
+
+    actualResult shouldBe 42
+  }
+
+  it should "lose a race regardless of argument order" in failAfter(unblockTimeLimit) {
+    val actualResult: Int = Async.run {
+      Async.race(
+        {
+          Async.delay(200.millis)
+          42
+        },
+        Async.never[Int]
+      )
+    }
+
+    actualResult shouldBe 42
+  }
+
+  it should "time out through Async.timeout, raising TimedOut" in failAfter(unblockTimeLimit) {
+    val actualResult: Int | Async.TimedOut = Raise.run {
+      Async.run {
+        Async.timeout(200.millis) {
+          Async.never[Int]
+        }
+      }
+    }
+
+    actualResult shouldBe Async.TimedOut
+  }
+
+  it should "be usable directly as the block's result type without an explicit call site cast" in failAfter(
+    unblockTimeLimit
+  ) {
+    // Compilation-level proof that `never[A]` unifies with any `A`, including a losing branch of
+    // `race` paired with a concrete, unrelated result type (String here, Int in other tests).
+    val actualResult: String = Async.run {
+      Async.race(
+        Async.never[String],
+        {
+          Async.delay(150.millis)
+          "done"
+        }
+      )
+    }
+
+    actualResult shouldBe "done"
+  }
+}

--- a/yaes-core/src/test/scala/io/yaes/AsyncRaceSuccessSpec.scala
+++ b/yaes-core/src/test/scala/io/yaes/AsyncRaceSuccessSpec.scala
@@ -514,6 +514,8 @@ class AsyncRaceSuccessSpec extends AnyFlatSpec with Matchers with TimeLimits {
       def delay(d: Duration): Unit                     = ()
       def fork[A](name: String)(block: => A): Fiber[A] =
         throw new UnsupportedOperationException("custom fork should have been used")
+      def never[A](): Nothing =
+        throw new UnsupportedOperationException("never is not exercised by this test")
     }
 
     a[UnsupportedOperationException] should be thrownBy {
@@ -552,6 +554,8 @@ class AsyncRaceSuccessSpec extends AnyFlatSpec with Matchers with TimeLimits {
       def fork[A](name: String)(block: => A): Fiber[A]                 = attemptFork(name)(block)
       override def attemptFork[A](name: String)(block: => A): Fiber[A] =
         new ImmediateFiber[A](name, block)
+      def never[A](): Nothing =
+        throw new UnsupportedOperationException("never is not exercised by this test")
     }
 
     val actualResult = Async.raceSuccess(1, 2)(using fake)

--- a/yaes-core/src/test/scala/io/yaes/AsyncRaceSuccessSpec.scala
+++ b/yaes-core/src/test/scala/io/yaes/AsyncRaceSuccessSpec.scala
@@ -514,7 +514,7 @@ class AsyncRaceSuccessSpec extends AnyFlatSpec with Matchers with TimeLimits {
       def delay(d: Duration): Unit                     = ()
       def fork[A](name: String)(block: => A): Fiber[A] =
         throw new UnsupportedOperationException("custom fork should have been used")
-      def never[A](): Nothing =
+      def never(): Nothing =
         throw new UnsupportedOperationException("never is not exercised by this test")
     }
 
@@ -554,7 +554,7 @@ class AsyncRaceSuccessSpec extends AnyFlatSpec with Matchers with TimeLimits {
       def fork[A](name: String)(block: => A): Fiber[A]                 = attemptFork(name)(block)
       override def attemptFork[A](name: String)(block: => A): Fiber[A] =
         new ImmediateFiber[A](name, block)
-      def never[A](): Nothing =
+      def never(): Nothing =
         throw new UnsupportedOperationException("never is not exercised by this test")
     }
 


### PR DESCRIPTION
Closes #309.

## What

Adds `Async.never[A](using Async): A` — a computation that parks the calling fiber indefinitely and never produces a value, exiting only through the standard interruption path.

```scala
val result = Async.run {
  Async.race(Async.never, { Async.delay(100.millis); 42 })
}
// result == 42
```

## How

- `Async.never[A](using async: Async): A` on the companion delegates to a new seam method `def never(): Nothing` on the `Async.Unsafe` trait.
- The JVM backend parks on a fresh, never counted down `CountDownLatch(1).await()`. It blocks without spinning and cannot wake spuriously, so no loop is needed. Its only exit is `InterruptedException`, which is the same signal `delay`'s `Thread.sleep` already raises and which `JvmAsync.forkImpl` already translates into `promise.cancel(true)`.
- `Unsafe.never` is deliberately abstract rather than defaulted: no safe default exists, since it cannot return, throwing would leak an untracked exception, and a spin loop would defeat the purpose. Its scaladoc says so and tells backend authors what to park on.

## Tests

12 tests in the new `AsyncNeverSpec`, all with `failAfter` guards so a regression fails rather than hangs:

- does not return on its own
- parks rather than spins (asserts the fiber thread is exactly `Thread.State.WAITING`, reached via a `CountDownLatch` handshake)
- `fiber.cancel()` stops it within a bounded time
- `Async.unsupervised` scope exit cancels it without an explicit cancel
- `join()` after cancellation throws nothing
- `value` after cancellation raises `Async.Cancelled`, not an untracked exception
- `race` and `raceSuccess` against a fast branch, both argument orders
- `timeout` raises `Async.TimedOut`
- unifies with a concrete non `Int` type as a race branch

`yaes-core/test` is green at 369 tests.

## Docs

`Async.never` added to the README combinator list and to the concurrency guide, with the foot gun spelled out: `never` must be forked and that fork cancelled, raced, or wrapped in `timeout`, otherwise the enclosing `Async.run` blocks permanently. `par` and `parTraverse` join every branch and so deadlock unconditionally when paired with `never`.

## Review

Three adversarial review rounds. Round 1 found 2 major and 5 minor issues, round 2 found 1 major and 2 minor, round 3 was clean. Notable fixes: scaladoc that recommended `par` as a use site (it deadlocks), safety claims that were false on the unforked path, the parking body moved behind the `Unsafe` seam so a non interrupt based backend cannot silently inherit an uncancellable `never`, an `IllegalStateException` on the unreachable line swapped for `InterruptedException` so even the impossible path cancels cleanly instead of poisoning the scope, and a parking assertion that a busy wait would have passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)