### PR TITLE
feat(308): add Async.detached for work that outlives the structured scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Using the `Async.fork` DSL is quite low-level. The library provides a set of str
 - `Async.parTraverse`: Executes a function over all elements of a collection in parallel, returning results in input order.
 - `Async.parTraverseLimit`: Like `Async.parTraverse`, but bounds how many invocations run at the same time.
 - `Async.never`: A computation that never completes on its own; useful as a branch of `Async.race`, `Async.raceSuccess`, or `Async.timeout` that must be cancelled or timed out rather than complete by itself. It must always be forked (directly or through a combinator like `race`) and that fork must be cancelled, raced away, or wrapped in a timeout, otherwise the enclosing `Async.run` blocks forever.
+- `Async.detached`: Starts a computation on its own background daemon virtual thread, completely outside any structured concurrency scope — it keeps running (and its failure stays contained, never propagating back) even after the scope that started it has exited. **This escapes structured concurrency** and should be reserved for genuine fire-and-forget background work.
 
 #### Parallel Traversal
 

--- a/website/src/content/docs/learn/5-concurrency.md
+++ b/website/src/content/docs/learn/5-concurrency.md
@@ -111,6 +111,35 @@ How it differs from `Async.run`:
 
 Supervision is a property of the scope, not of the fork. There is no separate "unsupervised fork" operation — `Async.fork` and `Async.forkNamed` work unchanged inside the block. Like `Async.run`, `Async.unsupervised` is a standalone handler providing its own `Async` capability, so it can be used on its own or nested in an existing scope. When nested, the enclosing scope is saved and restored, and is left untouched.
 
+### Detached Background Work
+
+`Async.fork`, `Async.run`, and `Async.unsupervised` all bind the work they start to a structured scope, so nothing they start can outlive that scope. `Async.detached` is the deliberate exception: it starts a computation on its own background daemon virtual thread, completely outside any scope, and returns immediately without waiting for it:
+
+```scala
+import io.yaes.Async
+
+Async.run {
+  val handle = Async.detached {
+    sendTelemetry() // keeps running even after this Async.run block returns
+  }
+  handle.onComplete(_ => println("telemetry sent"))
+  handle.onFailure(err => println(s"telemetry failed: ${err.getMessage}"))
+  "done"
+} // returns "done" immediately; the detached fiber is not waited on
+```
+
+`detached` gives the computation its own, freshly created `Async` capability with its own structured scope, so a failure inside it is contained there: it is captured for observers but never rethrown into the caller, so it can neither fail nor cancel the spawning scope. Because it runs on a virtual thread, the background thread is a daemon by construction — a detached computation left running never keeps the JVM alive on its own.
+
+The returned handle is fire-and-forget: it has no `join` or `cancel`, only `onComplete` and `onFailure` to observe the eventual outcome. Those callbacks are plain functions — they do not require an ambient `Async` — because the spawning scope may already be gone by the time they run. Registering an observer after the detached computation has already finished still fires it immediately.
+
+:::caution
+**`Async.detached` escapes structured concurrency.** Unlike `fork`, `run`, and `unsupervised`, the computation it starts is not cancelled when the spawning scope exits, its failure is never surfaced to that scope, and there is no way to join it from the caller. Reach for `fork` (inside `run` or `unsupervised`) for anything that should still respect structured concurrency; reach for `detached` only for genuine fire-and-forget background work, such as best-effort telemetry or logging, that must outlive the scope that started it.
+:::
+
+:::caution
+**The detached block must be self-terminating.** `detached` offers no `cancel`. A block that never completes — for example one that calls `Async.never` with nothing left to eventually interrupt it, since the fresh scope `detached` opens for it has nothing to cancel it either — leaves the returned handle permanently unsettled (no observer ever fires) and leaks its parked background thread for the lifetime of the JVM, with no way to reclaim it.
+:::
+
 ### Concurrency Primitives
 
 **Parallel Execution** — run two computations in parallel:

--- a/yaes-core/src/main/scala/io/yaes/Async.scala
+++ b/yaes-core/src/main/scala/io/yaes/Async.scala
@@ -154,6 +154,85 @@ class JvmFiber[A](
   }
 }
 
+/** A handle to a detached background computation started by [[Async.detached]].
+  *
+  * Unlike [[Fiber]], a `DetachedFiber` is not bound to any [[Async]] scope and offers no
+  * `join`/`cancel`/`value`: the computation it represents already runs on its own background daemon
+  * thread, independent of any [[StructuredTaskScope]], so there is no scope left to join or cancel
+  * it from. The only supported operation is attaching an observer that runs once the detached
+  * computation completes, successfully or not.
+  *
+  * Example:
+  * {{{
+  * val handle: DetachedFiber[Int] = Async.run {
+  *   Async.detached {
+  *     42
+  *   }
+  * }
+  * handle.onComplete(value => println(s"got $value"))
+  * handle.onFailure(err => println(s"failed: ${err.getMessage}"))
+  * }}}
+  *
+  * @tparam A
+  *   the type of value produced by the detached computation
+  */
+trait DetachedFiber[A] {
+
+  /** Registers a callback to run once the detached computation completes successfully.
+    *
+    * The callback does not require an ambient [[Async]] capability. If the detached computation has
+    * not completed yet, the callback runs on the detached background thread itself once it does. If
+    * the computation has ALREADY completed successfully by the time this is called, the callback
+    * instead runs synchronously and inline, on whatever thread called `onComplete` — so a slow or
+    * blocking callback registered late blocks the registering thread until it returns. Either way,
+    * the callback never runs on a thread of its own.
+    *
+    * An observer that throws is not propagated anywhere and does not prevent other observers
+    * registered on the same handle from running: the exception is silently discarded. Since
+    * observers are the only feedback channel for detached work, a throwing observer's failure is
+    * otherwise invisible.
+    *
+    * @param result
+    *   the callback function, receiving the computed value
+    */
+  def onComplete(result: A => Unit): Unit
+
+  /** Registers a callback to run if the detached computation fails with an exception.
+    *
+    * As with [[onComplete]], the callback does not require an ambient [[Async]] capability, runs
+    * either on the detached background thread or, if the computation has already failed,
+    * synchronously and inline on the registering thread, and an observer that throws is silently
+    * discarded without affecting other observers. It may also run well after the spawning scope has
+    * already exited.
+    *
+    * @param handler
+    *   the callback function, receiving the exception the computation failed with
+    */
+  def onFailure(handler: Throwable => Unit): Unit
+}
+
+/** JVM implementation of [[DetachedFiber]], backed by a plain [[CompletableFuture]].
+  *
+  * Unlike [[JvmFiber]], there is no `forkedThread` handshake and no cancellation: the underlying
+  * daemon thread is not owned by any [[StructuredTaskScope]], so there is nothing structured to
+  * cancel it from.
+  *
+  * @param promise
+  *   the CompletableFuture holding the detached computation's result
+  * @tparam A
+  *   the type of value produced by the detached computation
+  */
+class JvmDetachedFiber[A](private val promise: CompletableFuture[A]) extends DetachedFiber[A] {
+
+  override def onComplete(fn: A => Unit): Unit =
+    promise.thenAccept(result => fn(result))
+
+  override def onFailure(handler: Throwable => Unit): Unit =
+    promise.whenComplete { (_, ex) =>
+      if (ex != null) handler(ex)
+    }
+}
+
 /** JVM implementation of [[Async]] using Java's [[StructuredTaskScope]].
   *
   * This implementation provides structured concurrency support using Java's StructuredTaskScope
@@ -180,6 +259,49 @@ class JvmAsync extends Async.Unsafe {
     // unreachable path would cancel the fiber cleanly instead of poisoning the enclosing scope
     // with what would otherwise look like a genuine failure.
     throw new InterruptedException()
+  }
+
+  override def detached[A](block: Async ?=> A): DetachedFiber[A] = {
+    val promise = CompletableFuture[A]()
+    Thread
+      .ofVirtual()
+      .name(s"yaes-detached-${java.util.UUID.randomUUID()}")
+      .start(() => {
+        try {
+          val result = Async.run(block)
+          promise.complete(result)
+        } catch {
+          case ie: InterruptedException =>
+            // Treated as an ordinary failure, not a cancellation: this thread belongs to no
+            // StructuredTaskScope whose cancellation semantics `promise.cancel(true)` could
+            // mirror (that would also destroy the original exception, contradicting onFailure's
+            // documented contract of receiving the exception the computation failed with).
+            // Deliberately NOT restoring the interrupt status here (unlike standard JVM practice
+            // for a thread that keeps running): `CompletableFuture` runs any dependents already
+            // registered via `onComplete`/`onFailure` synchronously, on this very thread, as part
+            // of `completeExceptionally` below. Setting the interrupt flag first would make an
+            // observer's own interruptible blocking calls fail spuriously. This thread is about to
+            // terminate right after, so no later code could ever observe the flag anyway -- there
+            // is nothing for restoring it to protect.
+            promise.completeExceptionally(ie)
+          case NonFatal(t) =>
+            // Contained, not rethrown: `block`'s failure must never propagate anywhere, since
+            // this thread belongs to no structured scope that could observe it.
+            promise.completeExceptionally(t)
+          case fatal: Throwable =>
+            // Everything NonFatal does not match: genuine fatal errors (VirtualMachineError,
+            // LinkageError, ...) as well as scala.util.control.ControlThrowable (e.g. Raise's
+            // own private AccumulationError, see Raise.scala). Still recorded for observers, but
+            // also rethrown so it reaches this thread's default uncaught-exception handler,
+            // exactly like an equivalent failure would on any other unmanaged thread. This
+            // thread is not part of any StructuredTaskScope, so rethrowing here cannot reach the
+            // spawning scope or caller either way. Mirrors JvmAsync.forkImpl's identical
+            // treatment of this case.
+            promise.completeExceptionally(fatal)
+            throw fatal
+        }
+      })
+    new JvmDetachedFiber[A](promise)
   }
 }
 object JvmAsync {
@@ -976,6 +1098,106 @@ object Async {
     }
   }
 
+  /** Starts a detached computation on its own background daemon virtual thread, completely outside
+    * any structured concurrency scope.
+    *
+    * Every other entry point in this object — [[fork]], [[run]], [[unsupervised]] — binds the
+    * computation it starts to a [[StructuredTaskScope]], so it cannot outlive the scope that
+    * started it. `detached` is the deliberate exception: it starts `block` on a brand new daemon
+    * virtual thread that belongs to no scope at all, gives that thread its own fresh,
+    * self-contained [[Async]] capability (via an internal [[run]]), and returns immediately without
+    * waiting for it. A failure inside `block` is contained on that background thread; it is
+    * captured for observers but never rethrown into the caller, so it can neither fail nor cancel
+    * the spawning scope. The one exception is a genuinely fatal error (`VirtualMachineError`,
+    * `LinkageError`, ...): it is still captured for observers first, but is then also rethrown on
+    * the detached background thread itself, reaching that thread's default uncaught-exception
+    * handler -- never the caller's scope either way, since that thread belongs to no structured
+    * scope the caller could observe a rethrow through.
+    *
+    * Being a virtual thread, the background thread is a daemon by construction (the JVM's virtual
+    * threads are always daemons), so a detached computation left running never keeps the JVM alive
+    * on its own.
+    *
+    * The returned [[DetachedFiber]] is fire-and-forget: it exposes no `join`/`cancel`, only
+    * [[DetachedFiber.onComplete]] / [[DetachedFiber.onFailure]] to observe the eventual outcome.
+    *
+    * @note
+    *   '''This escapes structured concurrency.''' Unlike [[fork]], [[run]], and [[unsupervised]],
+    *   the computation started by `detached` is not cancelled when the spawning scope exits, its
+    *   failure is never surfaced to that scope, and there is no way to join it from the caller.
+    *   Reach for [[fork]] (inside [[run]] or [[unsupervised]]) for anything that should still
+    *   respect structured concurrency; reach for `detached` only for genuine fire-and-forget
+    *   background work (e.g. best-effort telemetry or logging) that must outlive the scope that
+    *   started it. Starting it still requires an ambient [[Async]] capability, exactly like every
+    *   other operation in this object: `detached` is a way to escape the spawning *scope*, not a
+    *   way to spawn concurrent work from code that holds no [[Async]] capability at all.
+    * @note
+    *   `block` must be self-terminating. `detached` offers no `cancel`, so a block that never
+    *   completes (for example one that calls [[never]] without anything to eventually interrupt
+    *   it, since the fresh scope `detached` opens for `block` has nothing left to cancel it either)
+    *   leaves the returned [[DetachedFiber]] permanently unsettled — no observer ever fires — and
+    *   leaks its parked background thread for the lifetime of the JVM, with no way to reclaim it.
+    * @note
+    *   An `InterruptedException` thrown by `block` is treated as an ordinary failure, not a
+    *   cancellation: it is reported to [[DetachedFiber.onFailure]] with its original type and
+    *   message intact. The background thread's interrupt status is deliberately NOT restored:
+    *   observers registered before completion run synchronously on this same, about-to-terminate
+    *   thread, and setting the flag would make an observer's own interruptible blocking calls fail
+    *   spuriously; nothing downstream ever gets a chance to observe the flag anyway. There is no
+    *   structured scope here for a cancellation signal to have come from, so, unlike [[fork]],
+    *   there is nothing to distinguish it from any other failure.
+    * @note
+    *   Observer callbacks passed to [[DetachedFiber.onComplete]] / [[DetachedFiber.onFailure]] are
+    *   plain `A => Unit` / `Throwable => Unit` functions: they do not receive an ambient [[Async]],
+    *   since the spawning scope (and the [[Async]] it provided) may already be gone by the time
+    *   they run. A callback that itself needs an [[Async]] capability can open its own with [[run]]
+    *   or [[unsupervised]].
+    * @note
+    *   `block` runs inside its own, freshly opened [[run]] scope, not bare. That scope applies
+    *   [[run]]'s usual rule: it waits for every fiber [[fork]]ed inside `block`, joined or not, and
+    *   if any of them fails, that failure wins over whatever `block` itself returned or threw. So
+    *   `Async.detached { Async.fork { throw Boom() }; 42 }` settles the returned [[DetachedFiber]]
+    *   exceptionally with `Boom()` -- the `42` is discarded -- even though `block` itself neither
+    *   threw nor was cancelled. Fibers forked inside `block` should be joined (or their failure
+    *   otherwise handled) before `block` returns, exactly as with a plain [[run]] call.
+    * @note
+    *   A [[Raise]] capability captured from the spawning scope and then used inside `block` does
+    *   not deliver its typed error at all: `Raise.raise` implements control flow via
+    *   `scala.util.boundary`/`break`, and the `boundary` frame that captured capability closed
+    *   over lives on the spawning thread's stack, not on this detached background thread. Using it
+    *   here throws a bare `scala.util.boundary.Break` instead, which is delivered to
+    *   [[DetachedFiber.onFailure]] like any other `NonFatal` failure rather than propagating the
+    *   typed error. Open a fresh [[Raise]] handler inside `block` instead.
+    *
+    * Example:
+    * {{{
+    * Async.run {
+    *   val handle = Async.detached {
+    *     sendTelemetry() // keeps running even after this Async.run block returns
+    *   }
+    *   handle.onComplete(_ => println("telemetry sent"))
+    *   handle.onFailure(err => println(s"telemetry failed: ${err.getMessage}"))
+    *   "done"
+    * } // returns "done" immediately; the detached fiber is not waited on
+    * }}}
+    *
+    * @param block
+    *   the computation to run detached; it receives its own freshly created [[Async]] capability,
+    *   with its own structured scope, independent of the caller's
+    * @param async
+    *   the async context; delegates to [[Async.Unsafe.detached]] for the actual spawning
+    *   implementation, exactly like every other `Async` operation delegates to its backend
+    * @tparam A
+    *   the type of value produced by the detached computation
+    * @return
+    *   a [[DetachedFiber]] handle for attaching completion/failure observers; it offers no
+    *   `join`/`cancel`, by design (see the note above)
+    * @see
+    *   [[unsupervised]], [[fork]] for the structured alternatives that remain bound to the spawning
+    *   scope
+    */
+  def detached[A](block: Async ?=> A)(using async: Async): DetachedFiber[A] = async.detached(block)
+
   opaque type Deadline = Duration
   object Deadline {
     def after(duration: Duration): Deadline = duration
@@ -1173,5 +1395,35 @@ object Async {
       *   never returns normally
       */
     def never(): Nothing
+
+    /** Starts `block` on its own background computation, detached from any structured concurrency
+      * scope, and returns a handle for observing its eventual outcome.
+      *
+      * This is the backend seam behind [[Async.detached]]. The JVM backend ([[JvmAsync]]) starts
+      * `block` on a brand new daemon virtual thread, gives it its own fresh [[Async]] capability via
+      * an internal [[Async.run]], and reports its outcome on a plain
+      * [[java.util.concurrent.CompletableFuture]] wrapped in a [[JvmDetachedFiber]]. `block`'s
+      * failure is always contained here (captured for observers, never rethrown to any caller),
+      * since the background computation this method starts belongs to no structured scope that
+      * could observe a rethrow. The one exception is a genuinely fatal error: it is still captured
+      * for observers first, but is then also rethrown on the detached background thread itself, so
+      * it still reaches that thread's own default uncaught-exception handler -- it just never
+      * reaches a caller, since there is no caller scope to reach.
+      *
+      * This method has no default implementation; every backend must supply its own, the same way
+      * [[never]] does, so that spawning genuinely detached work is not hard-coded to a single
+      * backend's concurrency primitive. Implement this by starting `block` on whatever background
+      * execution primitive the backend uses for concurrent work (a daemon thread, an unmanaged
+      * fiber, ...), running it fully outside of any structured scope the backend maintains, and
+      * reporting its outcome through a [[DetachedFiber]] implementation appropriate to the backend.
+      *
+      * @param block
+      *   the computation to run detached; it receives its own freshly created [[Async]] capability
+      * @tparam A
+      *   the type of value produced by the detached computation
+      * @return
+      *   a [[DetachedFiber]] handle for attaching completion/failure observers
+      */
+    def detached[A](block: Async ?=> A): DetachedFiber[A]
   }
 }

--- a/yaes-core/src/test/scala/io/yaes/AsyncDetachedSpec.scala
+++ b/yaes-core/src/test/scala/io/yaes/AsyncDetachedSpec.scala
@@ -1,0 +1,640 @@
+package io.yaes
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.concurrent.TimeLimits
+import org.scalatest.concurrent.Signaler
+import org.scalatest.concurrent.ThreadSignaler
+import org.scalatest.time.Seconds
+import org.scalatest.time.Span
+
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+import io.yaes.Async.*
+
+class AsyncDetachedSpec extends AnyFlatSpec with Matchers with TimeLimits {
+
+  /** Interrupts the test thread when a `failAfter` limit expires, turning a regression that hangs
+    * forever into a clean test failure.
+    */
+  private given Signaler = ThreadSignaler
+
+  /** Upper bound for every test in this spec. Generous enough to absorb CI jitter. */
+  private val unblockTimeLimit: Span = Span(30, Seconds)
+
+  /** Upper bound for every latch wait in this suite. */
+  private val AwaitTimeout = 5.seconds
+
+  /** Dedicated failure type for these tests, so `intercept`/`catch` clauses matching
+    * `RuntimeException` cannot accidentally absorb a failed assertion (`TestFailedException` is
+    * itself a `RuntimeException`).
+    */
+  private final class Boom(message: String) extends RuntimeException(message)
+
+  /** Waits for `latch`, bounded by [[AwaitTimeout]]. Returns `true` if the latch reached zero. */
+  private def awaitLatch(latch: CountDownLatch): Boolean =
+    latch.await(AwaitTimeout.toMillis, TimeUnit.MILLISECONDS)
+
+  "Async.detached" should "keep running and reach completion after the spawning Async.run block has already returned" in failAfter(
+    unblockTimeLimit
+  ) {
+    val release   = new CountDownLatch(1)
+    val completed = new CountDownLatch(1)
+    val order     = new ConcurrentLinkedQueue[String]()
+
+    Async.run {
+      Async.detached {
+        // Only proceeds once the parent test releases it, which happens strictly after
+        // Async.run below has already returned. If this ran inside the spawning scope,
+        // Async.run's own join() would have to wait for it and could never return first.
+        awaitLatch(release) shouldBe true
+        order.add("detached-done")
+        completed.countDown()
+      }
+      ()
+    }
+    order.add("run-returned")
+    release.countDown()
+
+    awaitLatch(completed) shouldBe true
+    order.toArray should contain theSameElementsInOrderAs List("run-returned", "detached-done")
+  }
+
+  it should "keep running and reach completion after the spawning Async.unsupervised block has already returned" in failAfter(
+    unblockTimeLimit
+  ) {
+    val release   = new CountDownLatch(1)
+    val completed = new CountDownLatch(1)
+    val order     = new ConcurrentLinkedQueue[String]()
+
+    Async.run {
+      Async.unsupervised {
+        Async.detached {
+          awaitLatch(release) shouldBe true
+          order.add("detached-done")
+          completed.countDown()
+        }
+        ()
+      }
+      order.add("unsupervised-returned")
+    }
+    release.countDown()
+
+    awaitLatch(completed) shouldBe true
+    order.toArray should contain theSameElementsInOrderAs List(
+      "unsupervised-returned",
+      "detached-done"
+    )
+  }
+
+  it should "require an ambient Async capability to be started, yet still let the computation escape the scope that started it" in failAfter(
+    unblockTimeLimit
+  ) {
+    // `detached` takes `using Async`, the same as every other capability-gated operation in this
+    // object. Unlike the comment-only claim this test used to make, this line actually exercises
+    // the gate: with no ambient Async capability in scope, `Async.detached { 42 }` fails to
+    // compile. Removing `(using async: Async)` from `Async.detached` would make this assertion
+    // itself fail (the snippet would newly compile), so this line has teeth where the runtime
+    // assertions below do not.
+    assertDoesNotCompile("Async.detached { 42 }")
+
+    val release   = new CountDownLatch(1)
+    val completed = new CountDownLatch(1)
+    val order     = new ConcurrentLinkedQueue[String]()
+
+    // The capability is needed only to *start* the background computation; once started, that
+    // computation still runs independent of, and outlives, the scope that provided the
+    // capability -- proven the same way as the first test above.
+    val handle = Async.run {
+      Async.detached[Int] {
+        awaitLatch(release) shouldBe true
+        order.add("detached-done")
+        42
+      }
+    }
+    order.add("run-returned")
+    release.countDown()
+
+    handle.onComplete(_ => completed.countDown())
+
+    awaitLatch(completed) shouldBe true
+    order.toArray should contain theSameElementsInOrderAs List("run-returned", "detached-done")
+  }
+
+  it should "start the computation on a virtual thread, which the JVM always treats as a daemon" in failAfter(
+    unblockTimeLimit
+  ) {
+    val threadRef = new AtomicReference[Thread]()
+    val done      = new CountDownLatch(1)
+
+    Async.run {
+      Async.detached {
+        threadRef.set(Thread.currentThread())
+        done.countDown()
+      }
+      ()
+    }
+
+    awaitLatch(done) shouldBe true
+    threadRef.get() should not be null
+    // This proves the background thread has the daemon/virtual properties that make "a detached
+    // computation left running never keeps the JVM alive on its own" true by construction (the
+    // JVM never waits for daemon threads before exiting). It does not itself observe the JVM
+    // actually exiting with only detached work outstanding, which would require driving a
+    // separate process.
+    threadRef.get().isDaemon shouldBe true
+    threadRef.get().isVirtual shouldBe true
+  }
+
+  it should "not propagate a failure thrown inside the detached computation to the spawning scope" in failAfter(
+    unblockTimeLimit
+  ) {
+    val release     = new CountDownLatch(1)
+    val aboutToFail = new CountDownLatch(1)
+
+    // The detached computation only throws once released, and it is released only after
+    // Async.run below has already returned. If the failure were somehow bound to the spawning
+    // scope (e.g. joined by it), Async.run could not have returned "parent-ok" first: it would
+    // have had to wait for, and then rethrow, the detached failure.
+    val result = Async.run {
+      Async.detached {
+        awaitLatch(release) shouldBe true
+        aboutToFail.countDown()
+        throw new Boom("detached boom")
+      }
+      "parent-ok"
+    }
+
+    result shouldBe "parent-ok"
+    release.countDown()
+
+    // Confirm the detached computation actually reached its throw, rather than relying on the
+    // 2-3ms window between Async.run returning and the assertion above being too short for the
+    // (not yet even started) detached block to have failed -- a bug that delayed or dropped the
+    // failure entirely would otherwise hide behind that timing coincidence.
+    awaitLatch(aboutToFail) shouldBe true
+  }
+
+  it should "not cancel sibling work in the spawning scope when the detached computation fails" in failAfter(
+    unblockTimeLimit
+  ) {
+    val siblingDone = new CountDownLatch(1)
+    val aboutToFail = new CountDownLatch(1)
+
+    val result = Async.run {
+      Async.detached {
+        aboutToFail.countDown()
+        throw new Boom("detached boom")
+      }
+      // Wait for the detached computation to have actually reached its throw before forking the
+      // sibling, so this test cannot pass merely because the detached block had not even started
+      // yet by the time the sibling ran.
+      awaitLatch(aboutToFail) shouldBe true
+
+      // A sibling fiber forked in the very same scope must run to completion untouched by the
+      // detached failure.
+      val sibling = Async.fork {
+        siblingDone.countDown()
+      }
+      sibling.join()
+      "sibling-ok"
+    }
+
+    result shouldBe "sibling-ok"
+    awaitLatch(siblingDone) shouldBe true
+  }
+
+  it should "surface an InterruptedException thrown by the detached computation to the failure observer with its original type and message intact" in failAfter(
+    unblockTimeLimit
+  ) {
+    val observed         = new CountDownLatch(1)
+    val observedFailure  = new AtomicReference[Throwable]()
+    val completeObserved = new AtomicBoolean(false)
+
+    val handle = Async.run {
+      Async.detached[Unit] {
+        throw new InterruptedException("interrupted boom")
+      }
+    }
+    handle.onComplete(_ => completeObserved.set(true))
+    handle.onFailure { err =>
+      observedFailure.set(err)
+      observed.countDown()
+    }
+
+    // Also proves the promise is never left incomplete on this path: if it were, neither observer
+    // above would ever fire and this await would time out and fail.
+    awaitLatch(observed) shouldBe true
+    observedFailure.get() shouldBe a[InterruptedException]
+    observedFailure.get().getMessage shouldBe "interrupted boom"
+    completeObserved.get() shouldBe false
+  }
+
+  it should "not leave the detached background thread's interrupt flag set for an onFailure observer registered before the InterruptedException is thrown" in failAfter(
+    unblockTimeLimit
+  ) {
+    val observerRegistered    = new CountDownLatch(1)
+    val observed              = new CountDownLatch(1)
+    val interruptedInObserver = new AtomicBoolean(true)
+
+    // The block only throws once the observer below has been registered, and registration
+    // happens strictly before this latch is released. That guarantees `promise.completeExceptionally`
+    // runs only after `onFailure` has already registered its callback with the still-incomplete
+    // `CompletableFuture`, so the callback is guaranteed to run synchronously, on this very
+    // detached background thread, rather than racily on whichever thread happens to register late.
+    val handle = Async.run {
+      Async.detached[Unit] {
+        awaitLatch(observerRegistered) shouldBe true
+        throw new InterruptedException("interrupted boom")
+      }
+    }
+    handle.onFailure { _ =>
+      // If the background thread's interrupt flag were set (e.g. by a `Thread.currentThread().interrupt()`
+      // call before `completeExceptionally`), it would be visible right here, since this callback
+      // runs on that same thread, synchronously, as part of completing the promise.
+      interruptedInObserver.set(Thread.currentThread().isInterrupted)
+      observed.countDown()
+    }
+    observerRegistered.countDown()
+
+    awaitLatch(observed) shouldBe true
+    interruptedInObserver.get() shouldBe false
+  }
+
+  it should "not leave the detached background thread's interrupt flag set for an onFailure observer registered before a NonFatal exception is thrown" in failAfter(
+    unblockTimeLimit
+  ) {
+    val observerRegistered    = new CountDownLatch(1)
+    val observed              = new CountDownLatch(1)
+    val interruptedInObserver = new AtomicBoolean(true)
+
+    // Mirrors the InterruptedException-path test above, but exercises the far more common
+    // NonFatal path instead. Its clear interrupt flag is not intrinsic to that arm: `block`
+    // runs inside its own internal `Async.run`, and it is that inner `Async.run`'s own
+    // `Thread.interrupted()` call (Async.scala's `run`, in its `case t: Throwable` arm) that
+    // undoes the interrupt flag `JvmAsync.ensureJoined` sets while tearing down the scope, before
+    // the exception is rethrown to this NonFatal arm and the promise is completed. An onFailure
+    // observer registered before completion runs synchronously on this same thread, so a stray
+    // `Thread.currentThread().interrupt()` anywhere on this path would be visible right here.
+    val handle = Async.run {
+      Async.detached[Unit] {
+        awaitLatch(observerRegistered) shouldBe true
+        throw new Boom("nonfatal boom")
+      }
+    }
+    handle.onFailure { _ =>
+      interruptedInObserver.set(Thread.currentThread().isInterrupted)
+      observed.countDown()
+    }
+    observerRegistered.countDown()
+
+    awaitLatch(observed) shouldBe true
+    interruptedInObserver.get() shouldBe false
+  }
+
+  it should "let a completion observer run with the value after the detached computation finishes, even once the spawning scope has exited" in failAfter(
+    unblockTimeLimit
+  ) {
+    val release       = new CountDownLatch(1)
+    val observed      = new CountDownLatch(1)
+    val observedValue = new AtomicReference[Int]()
+
+    val outerResult = Async.run {
+      val handle = Async.detached[Int] {
+        awaitLatch(release) shouldBe true
+        42
+      }
+      handle.onComplete { value =>
+        observedValue.set(value)
+        observed.countDown()
+      }
+      "scope-done"
+    }
+
+    outerResult shouldBe "scope-done"
+    // The spawning scope has already returned, and the observer has not fired yet: it does not
+    // require the scope, or an ambient Async, to eventually run.
+    observed.getCount shouldBe 1
+    release.countDown()
+
+    awaitLatch(observed) shouldBe true
+    observedValue.get() shouldBe 42
+  }
+
+  it should "let a failure observer run with the exception when the detached computation fails" in failAfter(
+    unblockTimeLimit
+  ) {
+    val release         = new CountDownLatch(1)
+    val observed        = new CountDownLatch(1)
+    val observedFailure = new AtomicReference[Throwable]()
+
+    Async.run {
+      val handle = Async.detached[Unit] {
+        awaitLatch(release) shouldBe true
+        throw new Boom("observed boom")
+      }
+      handle.onFailure { err =>
+        observedFailure.set(err)
+        observed.countDown()
+      }
+      ()
+    }
+
+    release.countDown()
+    awaitLatch(observed) shouldBe true
+    observedFailure.get() shouldBe a[Boom]
+    observedFailure.get().getMessage shouldBe "observed boom"
+  }
+
+  it should "run a completion observer registered after the detached computation has already finished" in failAfter(
+    unblockTimeLimit
+  ) {
+    val firstObserved  = new CountDownLatch(1)
+    val secondObserved = new CountDownLatch(1)
+    val secondValue    = new AtomicReference[Int]()
+
+    val handle = Async.run {
+      Async.detached[Int] {
+        99
+      }
+    }
+
+    handle.onComplete(_ => firstObserved.countDown())
+    awaitLatch(firstObserved) shouldBe true
+
+    // At this point the detached computation has already completed; a second, late observer,
+    // registered entirely outside any Async scope, must still fire.
+    handle.onComplete { value =>
+      secondValue.set(value)
+      secondObserved.countDown()
+    }
+
+    awaitLatch(secondObserved) shouldBe true
+    secondValue.get() shouldBe 99
+  }
+
+  it should "not fire the failure observer when the detached computation succeeds" in failAfter(
+    unblockTimeLimit
+  ) {
+    val completeObserved = new CountDownLatch(1)
+    val failureObserved  = new AtomicBoolean(false)
+
+    val handle = Async.run {
+      Async.detached[Int] { 7 }
+    }
+    handle.onFailure(_ => failureObserved.set(true))
+    handle.onComplete(_ => completeObserved.countDown())
+
+    // Wait on the *other* (successful) observer to know the computation has settled and both
+    // observers have had their chance to run, then assert the failure observer never fired.
+    awaitLatch(completeObserved) shouldBe true
+    failureObserved.get() shouldBe false
+  }
+
+  it should "not fire the completion observer when the detached computation fails" in failAfter(
+    unblockTimeLimit
+  ) {
+    val failureObserved  = new CountDownLatch(1)
+    val completeObserved = new AtomicBoolean(false)
+
+    val handle = Async.run {
+      Async.detached[Int] { throw new Boom("discrimination boom") }
+    }
+    handle.onComplete(_ => completeObserved.set(true))
+    handle.onFailure(_ => failureObserved.countDown())
+
+    // Wait on the *other* (failure) observer to know the computation has settled and both
+    // observers have had their chance to run, then assert the completion observer never fired.
+    awaitLatch(failureObserved) shouldBe true
+    completeObserved.get() shouldBe false
+  }
+
+  it should "not let a throwing observer prevent a second observer registered on the same handle from running" in failAfter(
+    unblockTimeLimit
+  ) {
+    val secondObserved = new CountDownLatch(1)
+    val secondValue    = new AtomicReference[Int]()
+
+    val handle = Async.run {
+      Async.detached[Int] { 7 }
+    }
+    handle.onComplete(_ => throw new Boom("observer boom"))
+    handle.onComplete { value =>
+      secondValue.set(value)
+      secondObserved.countDown()
+    }
+
+    awaitLatch(secondObserved) shouldBe true
+    secondValue.get() shouldBe 7
+  }
+
+  it should "not let a failing detached computation's exception escape to the JVM's default uncaught exception handler" in failAfter(
+    unblockTimeLimit
+  ) {
+    val threadRef       = new AtomicReference[Thread]()
+    val observed        = new CountDownLatch(1)
+    val uncaught        = new AtomicReference[Throwable]()
+    val previousHandler = Thread.getDefaultUncaughtExceptionHandler
+
+    Thread.setDefaultUncaughtExceptionHandler((_, ex) => uncaught.set(ex))
+    try {
+      val handle = Async.run {
+        Async.detached[Unit] {
+          threadRef.set(Thread.currentThread())
+          throw new Boom("uncaught-check boom")
+        }
+      }
+      handle.onFailure(_ => observed.countDown())
+
+      awaitLatch(observed) shouldBe true
+      // Wait for the background thread to fully terminate before checking the handler: if the
+      // exception had escaped (e.g. a `throw t` added after `promise.completeExceptionally(t)`),
+      // dispatching it to the handler happens as part of the thread's termination, which can race
+      // the onFailure callback above. Joining the thread waits past that point deterministically.
+      threadRef.get().join(AwaitTimeout.toMillis)
+      threadRef.get().isAlive shouldBe false
+      uncaught.get() shouldBe null
+    } finally {
+      Thread.setDefaultUncaughtExceptionHandler(previousHandler)
+    }
+  }
+
+  it should "surface a fatal error thrown inside the detached computation to both the failure observer and the JVM's default uncaught exception handler" in failAfter(
+    unblockTimeLimit
+  ) {
+    val threadRef       = new AtomicReference[Thread]()
+    val observed        = new CountDownLatch(1)
+    val observedFailure = new AtomicReference[Throwable]()
+    val uncaught        = new AtomicReference[Throwable]()
+    val previousHandler = Thread.getDefaultUncaughtExceptionHandler
+    val fatal           = new LinkageError("fatal boom")
+
+    // Unlike a NonFatal failure (the test above), a genuinely fatal error is not only contained
+    // for observers: it is also rethrown on the detached background thread itself, so it must
+    // still reach that thread's own default uncaught-exception handler, exactly like an
+    // equivalent failure would on any other unmanaged thread.
+    Thread.setDefaultUncaughtExceptionHandler((_, ex) => uncaught.set(ex))
+    try {
+      val handle = Async.run {
+        Async.detached[Unit] {
+          threadRef.set(Thread.currentThread())
+          throw fatal
+        }
+      }
+      handle.onFailure { err =>
+        observedFailure.set(err)
+        observed.countDown()
+      }
+
+      awaitLatch(observed) shouldBe true
+      observedFailure.get() shouldBe fatal
+
+      // Wait for the background thread to fully terminate before checking the handler: dispatch
+      // to the handler happens as part of the thread's termination, which can race the onFailure
+      // callback above. Joining the thread waits past that point deterministically.
+      threadRef.get().join(AwaitTimeout.toMillis)
+      threadRef.get().isAlive shouldBe false
+      uncaught.get() shouldBe fatal
+    } finally {
+      Thread.setDefaultUncaughtExceptionHandler(previousHandler)
+    }
+  }
+
+  it should "support a detached block that forks its own fibers internally" in failAfter(
+    unblockTimeLimit
+  ) {
+    val done  = new CountDownLatch(1)
+    val value = new AtomicReference[Int]()
+
+    val handle = Async.run {
+      Async.detached[Int] {
+        val innerResult = new AtomicReference[Int]()
+        val fiber       = Async.fork {
+          innerResult.set(21)
+          ()
+        }
+        fiber.join()
+        innerResult.get() * 2
+      }
+    }
+    handle.onComplete { v =>
+      value.set(v)
+      done.countDown()
+    }
+
+    awaitLatch(done) shouldBe true
+    value.get() shouldBe 42
+  }
+
+  it should "fail the handle with an unjoined child fiber's exception even though the block itself returned a value" in failAfter(
+    unblockTimeLimit
+  ) {
+    val observed         = new CountDownLatch(1)
+    val observedFailure  = new AtomicReference[Throwable]()
+    val completeObserved = new AtomicBoolean(false)
+
+    // `block` runs inside its own internal `Async.run` scope. That scope waits for every fiber
+    // forked inside it, joined or not, exactly like a top-level `Async.run` call would; if any of
+    // them fails, that failure -- not the value `block` returns -- becomes the outcome. Here
+    // `block` forks a fiber that fails and never joins it, then returns `42` and neither throws
+    // nor is itself cancelled; the handle must still fail with the child's exception, discarding
+    // the `42`.
+    val handle = Async.run {
+      Async.detached[Int] {
+        Async.fork {
+          throw new Boom("unjoined child boom")
+        }
+        42
+      }
+    }
+    handle.onComplete(_ => completeObserved.set(true))
+    handle.onFailure { err =>
+      observedFailure.set(err)
+      observed.countDown()
+    }
+
+    awaitLatch(observed) shouldBe true
+    observedFailure.get() shouldBe a[Boom]
+    observedFailure.get().getMessage shouldBe "unjoined child boom"
+    completeObserved.get() shouldBe false
+  }
+
+  it should "support a detached block nested inside another detached block" in failAfter(
+    unblockTimeLimit
+  ) {
+    val innerDone  = new CountDownLatch(1)
+    val innerValue = new AtomicReference[Int]()
+
+    Async.run {
+      Async.detached[Unit] {
+        val innerHandle = Async.detached[Int] { 5 }
+        innerHandle.onComplete { v =>
+          innerValue.set(v)
+          innerDone.countDown()
+        }
+        ()
+      }
+      ()
+    }
+
+    awaitLatch(innerDone) shouldBe true
+    innerValue.get() shouldBe 5
+  }
+
+  it should "let the completion observer fire with null when the detached block returns null" in failAfter(
+    unblockTimeLimit
+  ) {
+    val done  = new CountDownLatch(1)
+    val value = new AtomicReference[String]("not set")
+
+    val handle = Async.run {
+      Async.detached[String] {
+        null
+      }
+    }
+    handle.onComplete { v =>
+      value.set(v)
+      done.countDown()
+    }
+
+    awaitLatch(done) shouldBe true
+    value.get() shouldBe null
+  }
+
+  it should "let many detached blocks spawned concurrently from multiple threads all settle" in failAfter(
+    unblockTimeLimit
+  ) {
+    val spawnerCount = 8
+    val perSpawner   = 5
+    val total        = spawnerCount * perSpawner
+    val allDone      = new CountDownLatch(total)
+    val values       = new ConcurrentLinkedQueue[Int]()
+
+    val spawners = (0 until spawnerCount).map { i =>
+      val spawner = new Thread(() => {
+        (0 until perSpawner).foreach { j =>
+          val handle = Async.run {
+            Async.detached[Int] { i * perSpawner + j }
+          }
+          handle.onComplete { v =>
+            values.add(v)
+            allDone.countDown()
+          }
+        }
+      })
+      spawner.start()
+      spawner
+    }
+    spawners.foreach(_.join(AwaitTimeout.toMillis))
+
+    awaitLatch(allDone) shouldBe true
+    values.size() shouldBe total
+    values.asScala.toSet shouldBe (0 until total).toSet
+  }
+}

--- a/yaes-core/src/test/scala/io/yaes/AsyncRaceSuccessSpec.scala
+++ b/yaes-core/src/test/scala/io/yaes/AsyncRaceSuccessSpec.scala
@@ -516,6 +516,8 @@ class AsyncRaceSuccessSpec extends AnyFlatSpec with Matchers with TimeLimits {
         throw new UnsupportedOperationException("custom fork should have been used")
       def never(): Nothing =
         throw new UnsupportedOperationException("never is not exercised by this test")
+      def detached[A](block: Async ?=> A): DetachedFiber[A] =
+        throw new UnsupportedOperationException("detached is not exercised by this test")
     }
 
     a[UnsupportedOperationException] should be thrownBy {
@@ -556,6 +558,8 @@ class AsyncRaceSuccessSpec extends AnyFlatSpec with Matchers with TimeLimits {
         new ImmediateFiber[A](name, block)
       def never(): Nothing =
         throw new UnsupportedOperationException("never is not exercised by this test")
+      def detached[A](block: Async ?=> A): DetachedFiber[A] =
+        throw new UnsupportedOperationException("detached is not exercised by this test")
     }
 
     val actualResult = Async.raceSuccess(1, 2)(using fake)


### PR DESCRIPTION
Closes #308

## What

Adds `Async.detached`, an entry point that runs a block on a detached daemon virtual thread which no `StructuredTaskScope` owns, so the work survives the `Async.run` / `Async.unsupervised` block that spawned it. It returns a `DetachedFiber[A]` handle carrying `onComplete` / `onFailure` observers.

```scala
def detached[A](block: Async ?=> A)(using async: Async): DetachedFiber[A]

trait DetachedFiber[A] {
  def onComplete(result: A => Unit): Unit
  def onFailure(handler: Throwable => Unit): Unit
}

trait Async.Unsafe {
  def detached[A](block: Async ?=> A): DetachedFiber[A]
}
```

This is the second half of the `kyo-compat` GAP analysis (the first being `Async.unsupervised`, #302); together they unblock `CFiber.onComplete`.

## How

The detached thread comes from `Thread.ofVirtual().start`, which is not a `StructuredTaskScope` subtask, so scope teardown cannot interrupt it. Inside that thread the block runs under its own `Async.run`, so it gets a fully structured scope of its own and only the outer boundary is unstructured. `JvmAsync.scope` is a plain non-inheritable `ThreadLocal`, so the new thread starts with no ambient scope and cannot fork back into the dead parent.

Failure handling:

| thrown in the block | outcome |
| --- | --- |
| `NonFatal` | recorded on the handle, delivered to `onFailure`, never rethrown |
| `InterruptedException` | recorded on the handle with its original type and message intact |
| fatal (`LinkageError`, `VirtualMachineError`, ...) | recorded on the handle, then rethrown on the detached thread, reaching that thread's own uncaught-exception handler and nothing else |

Nothing on any path reaches the caller's thread or scope.

## Design decisions

- **Capability-gated.** `detached` requires `using Async` like every other concurrency operation, so it does not become an untracked thread spawn callable from pure code, even though its result escapes the scope.
- **Behind the `Async.Unsafe` seam.** Follows the precedent from when `never` moved there, so alternative backends can supply their own spawn primitive.
- **No `cancel` / `join`.** Fire-and-forget by design, per the issue. The consequence, documented explicitly, is that a block which never terminates leaks a parked thread and leaves the handle unsettled forever.
- **Interrupt flag deliberately not restored** on the detached thread. Observers registered before completion run synchronously on that same thread, and a set flag would make any interruptible call inside an observer throw immediately.
- **Observers need no ambient `Async`**, since by design the spawning scope may already be gone when one fires. An observer registered after completion runs inline on the registering thread.

## Tests

22 new tests in `AsyncDetachedSpec.scala`; module suite is 415/415 green.

Acceptance criteria coverage:

- outlives the scope, for both `Async.run` and `Async.unsupervised`
- runs on a virtual thread, which the JVM always treats as a daemon
- failure does not propagate to the spawning scope and does not cancel sibling work
- observers run after completion, with the value or the exception, once the scope has exited
- `onComplete` does not fire on failure and `onFailure` does not fire on success
- an observer registered after completion still runs
- a throwing observer does not prevent a second observer from running
- no uncaught exception escapes to the JVM default handler on the `NonFatal` path
- `InterruptedException` reaches `onFailure` with type and message intact
- a fatal error reaches both `onFailure` and the detached thread's uncaught handler
- observers see a clear interrupt flag on both the `NonFatal` and `InterruptedException` paths
- an unjoined child fiber's failure beats the block's own return value
- compile-time assertion that `detached` cannot be called without an ambient `Async`
- edge cases: forking inside a detached block, nesting `detached` inside `detached`, a `null` result, and many concurrent spawns all settling

Every wait is a bounded `CountDownLatch` whose result is asserted, and every test is wrapped in `failAfter` with a `ThreadSignaler`. The failure tests gate on a latch counted down at the point of failure, so they cannot pass by timing coincidence.

Three rounds of adversarial review were applied, each verified by mutation testing: every fix was proven to have teeth by breaking the implementation and confirming a test fails.

**Known gap:** the "with only detached work outstanding, the JVM is free to exit" criterion is proven at the property level (`isVirtual` / `isDaemon`) rather than by a subprocess test. Virtual threads being daemon threads is a JVM guarantee.

## Docs

Scaladoc on `detached`, `DetachedFiber` and the `Unsafe` seam method, with `{{{ }}}` examples (verified to compile) and explicit warnings that this escapes structured concurrency. Plus a README bullet and a new "Detached Background Work" section in the concurrency guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)